### PR TITLE
참여 중인 그룹 조회 API

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'mochat'
+rootProject.name = 'MYBG'

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -1,6 +1,7 @@
 package com.midasdev.mybg.group.controller;
 
 import com.midasdev.mybg.group.controller.dto.request.GroupCreateRequest;
+import com.midasdev.mybg.group.controller.dto.response.GroupListResponse;
 import com.midasdev.mybg.group.controller.dto.response.GroupResponse;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.service.GroupService;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,6 +44,13 @@ public class GroupController {
     public ResponseEntity<GroupResponse> findGroupByInvitationCode(@RequestParam String invitationCode) {
         Group group = groupService.findGroupByInvitationCode(invitationCode);
         return ResponseEntity.ok(GroupResponse.from(group));
+    }
+
+    @Operation(summary = "참여 중인 그룹 조회 API", description = "사용자가 참여 중인 그룹을 조회합니다.", security = @SecurityRequirement(name = "BearerAuth"))
+    @GetMapping("/participating")
+    public ResponseEntity<GroupListResponse> findGroupsByMemberId(@AuthenticationPrincipal Member member) {
+        List<Group> groups = groupService.findGroupsByMemberId(member);
+        return ResponseEntity.ok(GroupListResponse.from(groups));
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -49,7 +49,7 @@ public class GroupController {
     @Operation(summary = "참여 중인 그룹 조회 API", description = "사용자가 참여 중인 그룹을 조회합니다.", security = @SecurityRequirement(name = "BearerAuth"))
     @GetMapping("/participating")
     public ResponseEntity<GroupListResponse> findGroupsByMemberId(@AuthenticationPrincipal Member member) {
-        List<Group> groups = groupService.findGroupsByMemberId(member);
+        List<Group> groups = groupService.findGroupsByMember(member);
         return ResponseEntity.ok(GroupListResponse.from(groups));
     }
 

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Group APIs")
 @RestController
-@RequestMapping("/api/v1/group")
+@RequestMapping("/api/v1/groups")
 @RequiredArgsConstructor
 @Validated
 public class GroupController {

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupListResponse.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupListResponse.java
@@ -1,0 +1,15 @@
+package com.midasdev.mybg.group.controller.dto.response;
+
+import com.midasdev.mybg.group.domain.Group;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GroupListResponse(List<GroupResponse> groups) {
+
+    public static GroupListResponse from(List<Group> groups) {
+        return new GroupListResponse(groups.stream()
+                                           .map(GroupResponse::from)
+                                           .collect(Collectors.toList()));
+    }
+
+}

--- a/src/main/java/com/midasdev/mybg/group/domain/Group.java
+++ b/src/main/java/com/midasdev/mybg/group/domain/Group.java
@@ -52,7 +52,7 @@ public class Group {
     private String invitationCode;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "owner_member_id")
     private Member owner;
 
     @Column(nullable = false)

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
@@ -1,8 +1,11 @@
 package com.midasdev.mybg.group.repository;
 
 import com.midasdev.mybg.group.domain.Group;
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository {
     Optional<Group> findById(Long groupId);
+
+    List<Group> findGroupsByMemberId(Long memberId);
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
@@ -2,8 +2,10 @@ package com.midasdev.mybg.group.repository;
 
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.domain.QGroup;
+import com.midasdev.mybg.group_member.domain.QGroupMember;
 import com.midasdev.mybg.member.domain.QMember;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,5 +28,21 @@ public class GroupRepositoryImpl implements GroupRepository {
                                       .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    @Override
+    public List<Group> findGroupsByMemberId(Long memberId) {
+        QGroup group = QGroup.group;
+        QGroupMember groupMember = QGroupMember.groupMember;
+        QMember member = QMember.member;
+
+        return jpaQueryFactory.selectFrom(group)
+                .join(groupMember).on(group.eq(groupMember.group))
+                .fetchJoin()
+                .join(group.owner, member)
+                .fetchJoin()
+                .where(groupMember.member.id.eq(memberId))
+                .fetch()
+                .stream().toList();
     }
 }

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -7,9 +7,11 @@ import com.midasdev.mybg.global.exception.ApplicationExceptionType;
 import com.midasdev.mybg.global.util.assertion.Assertion;
 import com.midasdev.mybg.group.controller.dto.request.GroupCreateRequest;
 import com.midasdev.mybg.group.domain.Group;
+import com.midasdev.mybg.group.repository.GroupRepository;
 import com.midasdev.mybg.group.repository.GroupSpringDataRepository;
 import com.midasdev.mybg.group.service.component.InvitationCodeGenerator;
 import com.midasdev.mybg.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -26,6 +28,7 @@ public class GroupService {
 
     private final DefaultProfileImageService defaultProfileImageService;
     private final GroupSpringDataRepository groupSpringDataRepository;
+    private final GroupRepository groupRepository;
     private final InvitationCodeGenerator invitationCodeGenerator;
 
     @Transactional
@@ -62,6 +65,10 @@ public class GroupService {
         Assertion.with(invitationCode)
                  .setValidation(code -> code.length() == CODE_LENGTH)
                  .validateOrThrow(() -> new ApplicationException(ApplicationExceptionType.INVALID_INVITATION_CODE, invitationCode));
+    }
+
+    public List<Group> findGroupsByMember(Member member) {
+        return groupRepository.findGroupsByMemberId(member.getId());
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/group_member/domain/GroupMember.java
+++ b/src/main/java/com/midasdev/mybg/group_member/domain/GroupMember.java
@@ -44,7 +44,7 @@ public class GroupMember {
     @Column(name = "nickname", nullable = false)
     private String nickname;
 
-    @Column(name = "left_at", nullable = true)
+    @Column(name = "left_at")
     private LocalDateTime leftAt;
 
     @Embedded
@@ -52,11 +52,11 @@ public class GroupMember {
     private Audit audit = new Audit();
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     @ManyToOne
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
 }


### PR DESCRIPTION
# 🔍 Summary
참여 중인 그룹 조회 API 구현

# 📑 Description
요청을 보낸 사용자가 참여하고 있는 그룹 리스트를 반환합니다.

# 🔗 Related Issues
- #5 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정