### PR TITLE
참여 중인 그룹 조회 API에서 그룹 인원수 함께 조회

### DIFF
--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -58,8 +58,8 @@ public class GroupController {
         List<Group> groups = groupService.findGroupsByMember(member);
         return ResponseEntity.ok(GroupListResponse.from(groups));
     }
-    // TODO: BearerAuth 상수화
-    @Operation(summary = "그룹 인원 수 조회 API", description = "사용자가 참여 중인 그룹을 조회합니다.", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
+
+    @Operation(summary = "그룹 인원 수 조회 API", description = "그룹의 인원 수를 조회합니다.", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @GetMapping("/{groupId}/participants/count")
     public ResponseEntity<GroupMemberCountResponse> countGroupMembers(
             @Parameter(description = "그룹 ID", required = true)

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupResponse.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupResponse.java
@@ -5,7 +5,7 @@ import com.midasdev.mybg.group.domain.Group;
 import lombok.Builder;
 
 @Builder
-public record GroupResponse(long groupId, String name, String profileImageUrl, String invitationCode) {
+public record GroupResponse(long groupId, String name, String profileImageUrl, String invitationCode, int totalMemberCount) {
 
     public static GroupResponse from(Group group) {
         return GroupResponse.builder()
@@ -13,7 +13,7 @@ public record GroupResponse(long groupId, String name, String profileImageUrl, S
                             .name(group.getName())
                             .profileImageUrl(group.getProfileImageUrl())
                             .invitationCode(group.getInvitationCode())
+                            .totalMemberCount(group.getTotalMemberCount())
                             .build();
     }
-
 }

--- a/src/main/java/com/midasdev/mybg/group/domain/Group.java
+++ b/src/main/java/com/midasdev/mybg/group/domain/Group.java
@@ -12,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -34,7 +35,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
                 @UniqueConstraint(
                         name = "uq_invitation_code",
                         columnNames = { "invitation_code" })
-})
+        })
 public class Group {
 
     @Id
@@ -63,12 +64,19 @@ public class Group {
     @Default
     private Audit audit = new Audit();
 
+    @OneToOne(mappedBy = "group")
+    GroupStatistics groupStatistics;
+
     public void updateInvitationCode(String invitationCode) {
         this.invitationCode = invitationCode;
     }
 
     public boolean isOwner(Member member) {
         return this.owner.getId().equals(member.getId());
+    }
+
+    public int getTotalMemberCount() {
+        return this.groupStatistics.getTotalMemberCount();
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 public interface GroupRepository {
     Optional<Group> findById(Long groupId);
 
-    List<Group> findGroupsByMemberId(Long memberId);
+    List<Group> findGroupsWithStatisticsByMemberId(Long memberId);
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.midasdev.mybg.group.repository;
 
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.domain.QGroup;
+import com.midasdev.mybg.group.domain.QGroupStatistics;
 import com.midasdev.mybg.group_member.domain.QGroupMember;
 import com.midasdev.mybg.member.domain.QMember;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -31,8 +32,9 @@ public class GroupRepositoryImpl implements GroupRepository {
     }
 
     @Override
-    public List<Group> findGroupsByMemberId(Long memberId) {
+    public List<Group> findGroupsWithStatisticsByMemberId(Long memberId) {
         QGroup group = QGroup.group;
+        QGroupStatistics groupStatistics = QGroupStatistics.groupStatistics;
         QGroupMember groupMember = QGroupMember.groupMember;
         QMember member = QMember.member;
 
@@ -40,6 +42,8 @@ public class GroupRepositoryImpl implements GroupRepository {
                 .join(groupMember).on(group.eq(groupMember.group))
                 .fetchJoin()
                 .join(group.owner, member)
+                .fetchJoin()
+                .leftJoin(group.groupStatistics, groupStatistics)
                 .fetchJoin()
                 .where(groupMember.member.id.eq(memberId))
                 .fetch()

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -108,7 +108,7 @@ public class GroupService {
     }
 
     public List<Group> findGroupsByMember(Member member) {
-        return groupRepository.findGroupsByMemberId(member.getId());
+        return groupRepository.findGroupsWithStatisticsByMemberId(member.getId());
     }
 
     public int countGroupMembers(Long groupId) {


### PR DESCRIPTION
# 🔍 Summary
- 참여 중인 그룹 조회 API에서 그룹 인원수 함께 조회

# 📑 Description
- 참여 중인 그룹 조회 API Response에 그룹 인원수 추가
- `GroupEntity`에서 `GroupStatistics` 참조하도록 변경

# 🔗 Related Issues
- #13 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정