### PR TITLE
그룹 최대 인원 반영 및 그룹 통계 반영 관련 에러 수정

### DIFF
--- a/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
@@ -16,6 +16,11 @@ public enum ApplicationExceptionType {
     GROUP_NOT_FOUND_BY_ID(HttpStatus.BAD_REQUEST, "ERR_GROUP_001", "해당 ID의 그룹을 찾을 수 없습니다. : {0}"),
     GROUP_NOT_FOUND_BY_INVITATION_CODE(HttpStatus.BAD_REQUEST, "ERR_GROUP_002", "해당 초대 코드의 그룹을 찾을 수 없습니다. : {0}"),
     INVALID_INVITATION_CODE(HttpStatus.BAD_REQUEST, "ERR_GROUP_003", "유효하지 않은 초대 코드입니다. : {0}"),
+    GROUP_MEMBER_CAPACITY_REACHED(
+            HttpStatus.BAD_REQUEST,
+            "ERR_GROUP_004",
+            "그룹 최대 인원 수를 초과할 수 없습니다. (그룹 ID : {0})"
+    ),
 
     // group statistics
     GROUP_STATISTICS_NOT_FOUND_BY_ID(

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -41,8 +41,10 @@ public class GroupController {
     @PostMapping
     public ResponseEntity<GroupResponse> createGroup(@AuthenticationPrincipal Member member,
                                                      @Valid @RequestBody GroupCreateRequest groupCreateRequest) {
-        Group group = groupService.createGroup(member, groupCreateRequest);
-        return ResponseEntity.ok(GroupResponse.from(group));
+        Group savedGroup = groupService.createGroup(member, groupCreateRequest);
+        return ResponseEntity.ok(GroupResponse.from(
+                groupService.findGroupWithStatisticsById(savedGroup.getId())
+        ));
     }
 
     @Operation(summary = "그룹 조회 By 초대코드", description = "초대 코드로 그룹을 조회합니다.", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupCreateRequest.java
@@ -10,6 +10,9 @@ public record GroupCreateRequest(
         @NotBlank String name,
 
         @Schema(description = "그룹 프로필 이미지 URL", example = "https://example.com/image.jpg")
-        String profileImageUrl) {
+        String profileImageUrl,
 
+        @Schema(title = "그룹 최대 인원", example = "100", requiredMode = RequiredMode.REQUIRED)
+        int maxMemberCount
+) {
 }

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupCreateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupCreateRequest.java
@@ -2,6 +2,8 @@ package com.midasdev.mybg.group.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "그룹 생성 요청")
@@ -13,6 +15,7 @@ public record GroupCreateRequest(
         String profileImageUrl,
 
         @Schema(title = "그룹 최대 인원", example = "100", requiredMode = RequiredMode.REQUIRED)
+        @Min(1) @Max(500)
         int maxMemberCount
 ) {
 }

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupResponse.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/response/GroupResponse.java
@@ -5,7 +5,14 @@ import com.midasdev.mybg.group.domain.Group;
 import lombok.Builder;
 
 @Builder
-public record GroupResponse(long groupId, String name, String profileImageUrl, String invitationCode, int totalMemberCount) {
+public record GroupResponse(
+        long groupId,
+        String name,
+        String profileImageUrl,
+        String invitationCode,
+        int totalMemberCount,
+        int maxMemberCount
+) {
 
     public static GroupResponse from(Group group) {
         return GroupResponse.builder()
@@ -14,6 +21,8 @@ public record GroupResponse(long groupId, String name, String profileImageUrl, S
                             .profileImageUrl(group.getProfileImageUrl())
                             .invitationCode(group.getInvitationCode())
                             .totalMemberCount(group.getTotalMemberCount())
+                            .maxMemberCount(group.getMaxMemberCount())
                             .build();
     }
+
 }

--- a/src/main/java/com/midasdev/mybg/group/domain/Group.java
+++ b/src/main/java/com/midasdev/mybg/group/domain/Group.java
@@ -52,6 +52,9 @@ public class Group {
     @Column(nullable = false)
     private String invitationCode;
 
+    @Column(nullable = false)
+    private int maxMemberCount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_member_id")
     private Member owner;

--- a/src/main/java/com/midasdev/mybg/group/domain/Group.java
+++ b/src/main/java/com/midasdev/mybg/group/domain/Group.java
@@ -82,4 +82,8 @@ public class Group {
         return this.groupStatistics.getTotalMemberCount();
     }
 
+    public boolean isFull() {
+        return this.getTotalMemberCount() >= this.maxMemberCount;
+    }
+
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
@@ -7,5 +7,7 @@ import java.util.Optional;
 public interface GroupRepository {
     Optional<Group> findById(Long groupId);
 
+    Optional<Group> findWithStatisticsById(Long groupId);
+
     List<Group> findGroupsWithStatisticsByMemberId(Long memberId);
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepository.java
@@ -5,9 +5,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository {
+
     Optional<Group> findById(Long groupId);
 
     Optional<Group> findWithStatisticsById(Long groupId);
 
     List<Group> findGroupsWithStatisticsByMemberId(Long memberId);
+
+    Optional<Group> findByInvitationCode(String invitationCode);
+
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.midasdev.mybg.group.domain.QGroup;
 import com.midasdev.mybg.group.domain.QGroupStatistics;
 import com.midasdev.mybg.group_member.domain.QGroupMember;
 import com.midasdev.mybg.member.domain.QMember;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -37,16 +38,20 @@ public class GroupRepositoryImpl implements GroupRepository {
         QGroupStatistics groupStatistics = QGroupStatistics.groupStatistics;
         QMember member = QMember.member;
 
-        Group result = jpaQueryFactory.selectFrom(group)
-                                      .join(group.owner, member)
-                                      .fetchJoin()
-                                      .leftJoin(group.groupStatistics, groupStatistics)
-                                      .fetchJoin()
-                                      .where(group.id.eq(groupId)
-                                                     .and(group.deleted.isFalse()))
-                                      .fetchOne();
+        Group result = getGroupWithStatisticsQuery(group, member, groupStatistics)
+                .where(group.id.eq(groupId)
+                               .and(group.deleted.isFalse()))
+                .fetchOne();
 
         return Optional.ofNullable(result);
+    }
+
+    private JPAQuery<Group> getGroupWithStatisticsQuery(QGroup group, QMember member, QGroupStatistics groupStatistics) {
+        return jpaQueryFactory.selectFrom(group)
+                              .join(group.owner, member)
+                              .fetchJoin()
+                              .leftJoin(group.groupStatistics, groupStatistics)
+                              .fetchJoin();
     }
 
     @Override
@@ -66,6 +71,20 @@ public class GroupRepositoryImpl implements GroupRepository {
                               .where(groupMember.member.id.eq(memberId))
                               .fetch()
                               .stream().toList();
+    }
+
+    @Override
+    public Optional<Group> findByInvitationCode(String invitationCode) {
+        QGroup group = QGroup.group;
+        QGroupStatistics groupStatistics = QGroupStatistics.groupStatistics;
+        QMember member = QMember.member;
+
+        Group result = getGroupWithStatisticsQuery(group, member, groupStatistics)
+                .where(group.invitationCode.eq(invitationCode)
+                                           .and(group.deleted.isFalse()))
+                .fetchOne();
+        return Optional.ofNullable(result);
+
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
@@ -42,7 +42,8 @@ public class GroupRepositoryImpl implements GroupRepository {
                                       .fetchJoin()
                                       .leftJoin(group.groupStatistics, groupStatistics)
                                       .fetchJoin()
-                                      .where(group.id.eq(groupId))
+                                      .where(group.id.eq(groupId)
+                                                     .and(group.deleted.isFalse()))
                                       .fetchOne();
 
         return Optional.ofNullable(result);

--- a/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/group/repository/GroupRepositoryImpl.java
@@ -32,6 +32,23 @@ public class GroupRepositoryImpl implements GroupRepository {
     }
 
     @Override
+    public Optional<Group> findWithStatisticsById(Long groupId) {
+        QGroup group = QGroup.group;
+        QGroupStatistics groupStatistics = QGroupStatistics.groupStatistics;
+        QMember member = QMember.member;
+
+        Group result = jpaQueryFactory.selectFrom(group)
+                                      .join(group.owner, member)
+                                      .fetchJoin()
+                                      .leftJoin(group.groupStatistics, groupStatistics)
+                                      .fetchJoin()
+                                      .where(group.id.eq(groupId))
+                                      .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
     public List<Group> findGroupsWithStatisticsByMemberId(Long memberId) {
         QGroup group = QGroup.group;
         QGroupStatistics groupStatistics = QGroupStatistics.groupStatistics;
@@ -39,14 +56,15 @@ public class GroupRepositoryImpl implements GroupRepository {
         QMember member = QMember.member;
 
         return jpaQueryFactory.selectFrom(group)
-                .join(groupMember).on(group.eq(groupMember.group))
-                .fetchJoin()
-                .join(group.owner, member)
-                .fetchJoin()
-                .leftJoin(group.groupStatistics, groupStatistics)
-                .fetchJoin()
-                .where(groupMember.member.id.eq(memberId))
-                .fetch()
-                .stream().toList();
+                              .join(groupMember).on(group.eq(groupMember.group))
+                              .fetchJoin()
+                              .join(group.owner, member)
+                              .fetchJoin()
+                              .leftJoin(group.groupStatistics, groupStatistics)
+                              .fetchJoin()
+                              .where(groupMember.member.id.eq(memberId))
+                              .fetch()
+                              .stream().toList();
     }
+
 }

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -41,6 +41,11 @@ public class GroupService {
                                         .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID, groupId));
     }
 
+    public Group findGroupWithStatisticsById(Long groupId) {
+        return groupRepository.findWithStatisticsById(groupId)
+                                        .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID, groupId));
+    }
+
     @Transactional
     public Group createGroup(Member member, GroupCreateRequest groupCreateRequest) {
         String profileImageUrl = StringUtils.hasText(groupCreateRequest.profileImageUrl())

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -51,6 +51,7 @@ public class GroupService {
                            .owner(member)
                            .name(groupCreateRequest.name())
                            .profileImageUrl(profileImageUrl)
+                           .maxMemberCount(groupCreateRequest.maxMemberCount())
                            .deleted(false)
                            .build();
 

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -43,7 +43,7 @@ public class GroupService {
 
     public Group findGroupWithStatisticsById(Long groupId) {
         return groupRepository.findWithStatisticsById(groupId)
-                                        .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID, groupId));
+                              .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID, groupId));
     }
 
     @Transactional
@@ -102,9 +102,9 @@ public class GroupService {
     @Transactional(readOnly = true)
     public Group findGroupByInvitationCode(String invitationCode) {
         validateInvitationCode(invitationCode);
-        return groupSpringDataRepository.findByInvitationCode(invitationCode)
-                                        .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_INVITATION_CODE,
-                                                                                    invitationCode));
+        return groupRepository.findByInvitationCode(invitationCode)
+                              .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_INVITATION_CODE,
+                                                                          invitationCode));
     }
 
     private void validateInvitationCode(String invitationCode) {

--- a/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
+++ b/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
@@ -25,9 +25,15 @@ public class GroupMemberService {
     @Transactional
     public GroupMember joinGroup(Member member, GroupJoinRequest groupJoinRequest) {
         // group 검증
-        Group group = groupRepository.findById(groupJoinRequest.groupId())
+        Long requestedGroupId = groupJoinRequest.groupId();
+        Group group = groupRepository.findWithStatisticsById(requestedGroupId)
                                      .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID,
-                                                                                 groupJoinRequest.groupId()));
+                                                                                 requestedGroupId));
+        // group에 가입 가능한지 검증
+        if (group.isFull()) {
+            throw new ApplicationException(ApplicationExceptionType.GROUP_MEMBER_CAPACITY_REACHED, group.getId());
+        }
+
         // owner 인지 검증
         if (isAlreadyGroupMember(member, group)) {
             throw new ApplicationException(ApplicationExceptionType.ALREADY_JOINED_GROUP, member.getId(), group.getId());


### PR DESCRIPTION
# 🔍 Summary
- 그룹 최대 인원 설정을 이제까지 구현된 API 에 반영
- 그룹 통계 반영 후 발생한 에러 수정

# 📑 Description
- 그릅 최대 인원 테이블 및 엔티티에 추가
- 그룹 생성 로직 반영
- 그룹 가입 시 최대 인원 검증
- 그룹 통계 반영 후 생긴 초대코드 조회 API N+1 문제 해결

# 🔗 Related Issues
- #15 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정