### PR TITLE
그룹 정보 수정 API

### DIFF
--- a/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
@@ -22,6 +22,26 @@ public enum ApplicationExceptionType {
             "그룹 최대 인원 수를 초과할 수 없습니다. (그룹 ID : {0})"
     ),
 
+    /**
+     * - {0} : maxMemberCount (요청한 최대 인원 수)
+     * - {1} : totalMemberCount (현재 그룹 인원 수)
+     */
+    GROUP_MAX_COUNT_BELOW_CURRENT(
+            HttpStatus.BAD_REQUEST,
+            "ERR_GROUP_005",
+            "현재 인원 수({1})보다 작은 최대 인원 수({0})로 변경할 수 없습니다."
+    ),
+
+    /**
+     * - {0} : memberId (요청한 사용자 ID)
+     * - {1} : groupId (그룹 ID)
+     */
+    GROUP_UPDATE_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "ERR_GROUP_006",
+            "그룹 정보를 수정할 권한이 없습니다. 요청자(memberId: {0})는 그룹(groupId: {1})의 소유자가 아닙니다."
+    ),
+
     // group statistics
     GROUP_STATISTICS_NOT_FOUND_BY_ID(
             HttpStatus.BAD_REQUEST,

--- a/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
+++ b/src/main/java/com/midasdev/mybg/global/exception/ApplicationExceptionType.java
@@ -130,6 +130,11 @@ public enum ApplicationExceptionType {
      * - {0} : Exception Message
      */
     GLOBAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ERR_GLOBAL_003", "서버 내부 에러입니다. : {0}"),
+    GLOBAL_NO_UPDATE_FIELD_PROVIDED(
+            HttpStatus.BAD_REQUEST,
+            "ERR_GLOBAL_004",
+            "수정할 항목이 없습니다."
+    ),
     UNDEFINED_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "ERR_GLOBAL_999", "정의되지 않은 에러입니다. : {0}");
 
     public static ApplicationExceptionType resolveExceptionType(Exception exception) {

--- a/src/main/java/com/midasdev/mybg/global/s3/S3Directory.java
+++ b/src/main/java/com/midasdev/mybg/global/s3/S3Directory.java
@@ -1,0 +1,15 @@
+package com.midasdev.mybg.global.s3;
+
+import lombok.Getter;
+
+@Getter
+public enum S3Directory {
+    GROUP_PROFILE_IMAGES("group_profile_images"),
+    GROUP_MEMBER_PROFILE_IMAGES("group_member_profile_images");
+
+    private final String directory;
+
+    S3Directory(String directory) {
+        this.directory = directory;
+    }
+}

--- a/src/main/java/com/midasdev/mybg/global/s3/S3ImageService.java
+++ b/src/main/java/com/midasdev/mybg/global/s3/S3ImageService.java
@@ -29,11 +29,11 @@ public class S3ImageService {
     @Value("${aws.s3.bucket-name}")
     private String bucketName;
 
-    public String upload(MultipartFile multipartFile, String dirName) {
+    public String upload(MultipartFile multipartFile, S3Directory directory) {
         validateImageFile(multipartFile);
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
-        String filePath = dirName + "/" + fileName;
+        String filePath = directory.getDirectory() + "/" + fileName;
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -47,7 +47,7 @@ public class S3ImageService {
             throw new ApplicationException(ApplicationExceptionType.S3_FILE_UPLOAD_EXCEPTION, e);
         }
 
-        return resourceUrlGenerator.generateS3Url(dirName, fileName);
+        return resourceUrlGenerator.generateS3Url(directory.getDirectory(), fileName);
     }
 
     private void validateImageFile(MultipartFile multipartFile) {

--- a/src/main/java/com/midasdev/mybg/global/util/validator/FileMaxSize.java
+++ b/src/main/java/com/midasdev/mybg/global/util/validator/FileMaxSize.java
@@ -1,0 +1,24 @@
+package com.midasdev.mybg.global.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = FileMaxSizeValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FileMaxSize {
+
+    String message() default "파일 크기가 {value}바이트를 초과할 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    long value(); // 최대 바이트 크기
+}

--- a/src/main/java/com/midasdev/mybg/global/util/validator/FileMaxSizeValidator.java
+++ b/src/main/java/com/midasdev/mybg/global/util/validator/FileMaxSizeValidator.java
@@ -1,0 +1,23 @@
+package com.midasdev.mybg.global.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class FileMaxSizeValidator implements ConstraintValidator<FileMaxSize, MultipartFile> {
+
+    private long maxSize;
+
+    @Override
+    public void initialize(FileMaxSize constraintAnnotation) {
+        this.maxSize = constraintAnnotation.value();
+    }
+
+    @Override
+    public boolean isValid(MultipartFile file, ConstraintValidatorContext context) {
+        if (file == null || file.isEmpty()) {
+            return true; // null or 비어있으면 검사 대상 아님
+        }
+        return file.getSize() <= maxSize;
+    }
+}

--- a/src/main/java/com/midasdev/mybg/global/util/validator/NotBlankIfPresent.java
+++ b/src/main/java/com/midasdev/mybg/global/util/validator/NotBlankIfPresent.java
@@ -1,0 +1,22 @@
+package com.midasdev.mybg.global.util.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = NotBlankIfPresentValidator.class)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotBlankIfPresent {
+
+    String message() default "공백만 포함된 문자열은 허용되지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/midasdev/mybg/global/util/validator/NotBlankIfPresentValidator.java
+++ b/src/main/java/com/midasdev/mybg/global/util/validator/NotBlankIfPresentValidator.java
@@ -1,0 +1,13 @@
+package com.midasdev.mybg.global.util.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotBlankIfPresentValidator implements ConstraintValidator<NotBlankIfPresent, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // null은 허용, blank는 불허
+        return value == null || !value.isBlank();
+    }
+}

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -76,10 +76,14 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "그룹 정보 수정 API",
-            description = "그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.\n" +
-                    "그룹 소유자만 수정할 수 있습니다.",
-            security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
+        summary = "그룹 정보 수정 API",
+        description = """
+            그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.
+            - Request DTO : GroupUpdateRequest
+            - 세부사항:
+                1. 그룹 소유자만 수정할 수 있습니다.
+            """,
+        security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     )
     @PatchMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<GroupResponse> updateGroup(

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -70,20 +70,21 @@ public class GroupController {
     @GetMapping("/{groupId}/participants/count")
     public ResponseEntity<GroupMemberCountResponse> countGroupMembers(
             @Parameter(description = "그룹 ID", required = true)
-            @PathVariable @IsPositiveNumber Long groupId) {
+            @PathVariable @IsPositiveNumber Long groupId
+    ) {
         int groupMemberCount = groupService.countGroupMembers(groupId);
         return ResponseEntity.ok(new GroupMemberCountResponse(groupId, groupMemberCount));
     }
 
     @Operation(
-        summary = "그룹 정보 수정 API",
-        description = """
-            그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.
-            - Request DTO : GroupUpdateRequest
-            - 세부사항:
-                1. 그룹 소유자만 수정할 수 있습니다.
-            """,
-        security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
+            summary = "그룹 정보 수정 API",
+            description = """
+                    그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.
+                    - Request DTO : GroupUpdateRequest
+                    - 세부사항:
+                        1. 그룹 소유자만 수정할 수 있습니다.
+                    """,
+            security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     )
     @PatchMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<GroupResponse> updateGroup(
@@ -91,6 +92,7 @@ public class GroupController {
             @AuthenticationPrincipal Member member,
             @Valid @ModelAttribute GroupUpdateRequest request
     ) {
+        request.validateAtLeastOneFieldPresent();
         Group updatedGroup = groupService.updateGroup(groupId, member, request);
         return ResponseEntity.ok(GroupResponse.from(updatedGroup));
     }

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -82,15 +82,14 @@ public class GroupController {
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     )
     @PatchMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> updateGroup(
+    public ResponseEntity<GroupResponse> updateGroup(
             @PathVariable Long groupId,
             @AuthenticationPrincipal Member member,
             @Valid @ModelAttribute GroupUpdateRequest request
     ) {
-        groupService.updateGroup(groupId, member, request);
-        return ResponseEntity.ok().build();
+        Group updatedGroup = groupService.updateGroup(groupId, member, request);
+        return ResponseEntity.ok(GroupResponse.from(updatedGroup));
     }
-
 
 
 }

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -4,6 +4,7 @@ import static com.midasdev.mybg.config.swagger.SwaggerConfig.SECURITY_SCHEME_NAM
 
 import com.midasdev.mybg.global.util.validator.IsPositiveNumber;
 import com.midasdev.mybg.group.controller.dto.request.GroupCreateRequest;
+import com.midasdev.mybg.group.controller.dto.request.GroupUpdateRequest;
 import com.midasdev.mybg.group.controller.dto.response.GroupListResponse;
 import com.midasdev.mybg.group.controller.dto.response.GroupMemberCountResponse;
 import com.midasdev.mybg.group.controller.dto.response.GroupResponse;
@@ -17,10 +18,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,6 +73,21 @@ public class GroupController {
             @PathVariable @IsPositiveNumber Long groupId) {
         int groupMemberCount = groupService.countGroupMembers(groupId);
         return ResponseEntity.ok(new GroupMemberCountResponse(groupId, groupMemberCount));
+    }
+
+    @Operation(
+            summary = "그룹 정보 수정 API",
+            description = "그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다. (오너만 가능)",
+            security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
+    )
+    @PatchMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> updateGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal Member member,
+            @Valid @ModelAttribute GroupUpdateRequest request
+    ) {
+        groupService.updateGroup(groupId, member, request);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -77,7 +77,8 @@ public class GroupController {
 
     @Operation(
             summary = "그룹 정보 수정 API",
-            description = "그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다. (오너만 가능)",
+            description = "그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.\n" +
+                    "그룹 소유자만 수정할 수 있습니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
     )
     @PatchMapping(value = "/{groupId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
@@ -8,7 +8,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
-@Schema(description = "그룹 정보 수정 Request")
+@Schema(
+        description = """
+        그룹 정보 수정 Request
+        - 프로필 이미지는 jpg, jpeg, png, gif 형식만 허용되며, 최대 3MB까지 업로드할 수 있습니다.
+        - 각 필드는 선택 사항이며, null인 경우 해당 항목은 변경되지 않습니다.
+                - 수정하지 않을 시 반드시 null 입력        
+        """
+)
 public record GroupUpdateRequest(
 
         @Schema(

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.midasdev.mybg.group.controller.dto.request;
 
+import com.midasdev.mybg.global.exception.ApplicationException;
+import com.midasdev.mybg.global.exception.ApplicationExceptionType;
 import com.midasdev.mybg.global.util.validator.FileMaxSize;
 import com.midasdev.mybg.global.util.validator.NotBlankIfPresent;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,11 +12,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Schema(
         description = """
-        그룹 정보 수정 Request
-        - 프로필 이미지는 jpg, jpeg, png, gif 형식만 허용되며, 최대 3MB까지 업로드할 수 있습니다.
-        - 각 필드는 선택 사항이며, null인 경우 해당 항목은 변경되지 않습니다.
-                - 수정하지 않을 시 반드시 null 입력        
-        """
+                그룹 정보 수정 Request
+                - 프로필 이미지는 jpg, jpeg, png, gif 형식만 허용되며, 최대 3MB까지 업로드할 수 있습니다.
+                - 각 필드는 선택 사항이며, null인 경우 해당 항목은 변경되지 않습니다.
+                        - 수정하지 않을 시 반드시 null 입력
+                """
 )
 public record GroupUpdateRequest(
 
@@ -43,4 +45,17 @@ public record GroupUpdateRequest(
         @Max(value = 1000, message = "최대 인원 수는 1000명을 초과할 수 없습니다.")
         Integer maxMemberCount
 
-) {}
+) {
+
+    /**
+     * 최소 1개 필드가 null이 아닌지 검증합니다.
+     *
+     * @throws ApplicationException 최소 1개 필드가 null이 아닐 경우
+     */
+    public void validateAtLeastOneFieldPresent() {
+        if (name == null && profileImage == null && maxMemberCount == null) {
+            throw new ApplicationException(ApplicationExceptionType.GLOBAL_NO_UPDATE_FIELD_PROVIDED);
+        }
+    }
+
+}

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.midasdev.mybg.group.controller.dto.request;
 
 import com.midasdev.mybg.global.util.validator.FileMaxSize;
+import com.midasdev.mybg.global.util.validator.NotBlankIfPresent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.Max;
@@ -15,6 +16,7 @@ public record GroupUpdateRequest(
                 example = "우리 가족방",
                 requiredMode = RequiredMode.NOT_REQUIRED
         )
+        @NotBlankIfPresent
         @Size(max = 25, message = "그룹 이름은 최대 25자까지 가능합니다.")
         String name,
 

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.midasdev.mybg.group.controller.dto.request;
 
+import com.midasdev.mybg.global.util.validator.FileMaxSize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.Max;
@@ -22,6 +23,7 @@ public record GroupUpdateRequest(
                 format = "binary",
                 requiredMode = RequiredMode.NOT_REQUIRED
         )
+        @FileMaxSize(value = 3 * 1024 * 1024, message = "파일 크기가 3MB를 초과할 수 없습니다.")
         MultipartFile profileImage,
 
         @Schema(

--- a/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/dto/request/GroupUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.midasdev.mybg.group.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "그룹 정보 수정 Request")
+public record GroupUpdateRequest(
+
+        @Schema(
+                description = "변경할 그룹 이름 (최대 25자)",
+                example = "우리 가족방",
+                requiredMode = RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 25, message = "그룹 이름은 최대 25자까지 가능합니다.")
+        String name,
+
+        @Schema(
+                description = "변경할 그룹 프로필 이미지 (jpg, jpeg, png, gif), 변경하지 않을 시 null, 최대 3MB",
+                format = "binary",
+                requiredMode = RequiredMode.NOT_REQUIRED
+        )
+        MultipartFile profileImage,
+
+        @Schema(
+                description = "최대 인원 수 (최대 1000명)",
+                example = "10",
+                requiredMode = RequiredMode.NOT_REQUIRED
+        )
+        @Max(value = 1000, message = "최대 인원 수는 1000명을 초과할 수 없습니다.")
+        Integer maxMemberCount
+
+) {}

--- a/src/main/java/com/midasdev/mybg/group/domain/Group.java
+++ b/src/main/java/com/midasdev/mybg/group/domain/Group.java
@@ -1,6 +1,8 @@
 package com.midasdev.mybg.group.domain;
 
 import com.midasdev.mybg.global.audit.Audit;
+import com.midasdev.mybg.global.exception.ApplicationException;
+import com.midasdev.mybg.global.exception.ApplicationExceptionType;
 import com.midasdev.mybg.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -84,6 +86,25 @@ public class Group {
 
     public boolean isFull() {
         return this.getTotalMemberCount() >= this.maxMemberCount;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateMaxMemberCount(int newMaxCount) {
+        int currentTotal = this.getTotalMemberCount();
+        if (newMaxCount < currentTotal) {
+            throw new ApplicationException(
+                    ApplicationExceptionType.GROUP_MAX_COUNT_BELOW_CURRENT,
+                    newMaxCount, currentTotal
+            );
+        }
+        this.maxMemberCount = newMaxCount;
+    }
+
+    public void updateProfileImageUrl(String imageUrl) {
+        this.profileImageUrl = imageUrl;
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -78,6 +78,8 @@ public class GroupService {
         GroupMember owner = GroupMember.builder()
                                        .nickname(member.getName())
                                        .group(savedGroup)
+                                       // TODO: 그룹 생성 시 그룹 내의 방장 프로필 이미지 설정 여부 검토
+                                       .memberProfileImageUrl(member.getProfileImageUrl())
                                        .member(member)
                                        .build();
         groupMemberSpringDataRepository.save(owner);

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -155,12 +155,12 @@ public class GroupService {
             );
         }
 
-        // 3. 그룹 이름 변경 (blank 검증은 DTO 어노테이션으로 처리됨)
+        // 3. 그룹 이름 변경
         if (request.name() != null) {
             group.updateName(request.name());
         }
 
-        // 4. 최대 인원 수 변경 (현재 인원보다 작을 수 없음 → 도메인에서 검증)
+        // 4. 최대 인원 수 변경
         if (request.maxMemberCount() != null) {
             group.updateMaxMemberCount(request.maxMemberCount());
         }

--- a/src/main/java/com/midasdev/mybg/group/service/GroupService.java
+++ b/src/main/java/com/midasdev/mybg/group/service/GroupService.java
@@ -4,8 +4,11 @@ import com.midasdev.mybg.global.application.DefaultProfileImageService;
 import com.midasdev.mybg.global.application.DefaultProfileImageType;
 import com.midasdev.mybg.global.exception.ApplicationException;
 import com.midasdev.mybg.global.exception.ApplicationExceptionType;
+import com.midasdev.mybg.global.s3.S3Directory;
+import com.midasdev.mybg.global.s3.S3ImageService;
 import com.midasdev.mybg.global.util.assertion.Assertion;
 import com.midasdev.mybg.group.controller.dto.request.GroupCreateRequest;
+import com.midasdev.mybg.group.controller.dto.request.GroupUpdateRequest;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.domain.GroupStatistics;
 import com.midasdev.mybg.group.repository.GroupRepository;
@@ -15,12 +18,14 @@ import com.midasdev.mybg.group.service.component.InvitationCodeGenerator;
 import com.midasdev.mybg.group_member.domain.GroupMember;
 import com.midasdev.mybg.group_member.repository.GroupMemberSpringDataRepository;
 import com.midasdev.mybg.member.domain.Member;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -30,6 +35,7 @@ public class GroupService {
     private static final int CODE_LENGTH = 8;
 
     private final DefaultProfileImageService defaultProfileImageService;
+    private final S3ImageService s3ImageService;
     private final GroupSpringDataRepository groupSpringDataRepository;
     private final GroupRepository groupRepository;
     private final InvitationCodeGenerator invitationCodeGenerator;
@@ -126,5 +132,48 @@ public class GroupService {
                                                                            ApplicationExceptionType.GROUP_STATISTICS_NOT_FOUND_BY_ID, group.getId()));
         return groupStatistics.getTotalMemberCount();
     }
+
+    /**
+     * 그룹 정보 수정
+     * - 그룹 이름, 최대 인원 수, 프로필 이미지를 수정할 수 있다
+     * - 그룹 오너만 수정 가능하며, 각 필드가 null이 아닌 경우에만 변경
+     */
+    @Transactional
+    public Group updateGroup(Long groupId, Member member, GroupUpdateRequest request) {
+        // 1. 그룹 조회
+        Group group = groupRepository.findById(groupId)
+                                     .orElseThrow(() -> new ApplicationException(
+                                             ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID,
+                                             groupId
+                                     ));
+
+        // 2. 그룹 소유자인지 검증
+        if (!group.isOwner(member)) {
+            throw new ApplicationException(
+                    ApplicationExceptionType.GROUP_UPDATE_FORBIDDEN,
+                    member.getId(), groupId
+            );
+        }
+
+        // 3. 그룹 이름 변경 (blank 검증은 DTO 어노테이션으로 처리됨)
+        if (request.name() != null) {
+            group.updateName(request.name());
+        }
+
+        // 4. 최대 인원 수 변경 (현재 인원보다 작을 수 없음 → 도메인에서 검증)
+        if (request.maxMemberCount() != null) {
+            group.updateMaxMemberCount(request.maxMemberCount());
+        }
+
+        // 5. 프로필 이미지 업로드 및 변경
+        MultipartFile image = request.profileImage();
+        if (image != null && !image.isEmpty()) {
+            String imageUrl = s3ImageService.upload(image, S3Directory.GROUP_PROFILE_IMAGES);
+            group.updateProfileImageUrl(imageUrl);
+        }
+
+        return group;
+    }
+
 
 }

--- a/src/main/java/com/midasdev/mybg/group_member/controller/dto/request/GroupMemberProfileUpdateRequest.java
+++ b/src/main/java/com/midasdev/mybg/group_member/controller/dto/request/GroupMemberProfileUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.midasdev.mybg.group_member.controller.dto.request;
 
+import com.midasdev.mybg.global.util.validator.FileMaxSize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.Size;
@@ -13,6 +14,7 @@ public record GroupMemberProfileUpdateRequest(
         String nickname,
 
         @Schema(description = "프로필 이미지 파일 (jpg, jpeg, png, gif), 변경하지 않을 시 null", format = "binary", requiredMode = RequiredMode.NOT_REQUIRED)
+        @FileMaxSize(value = 3 * 1024 * 1024, message = "파일 크기가 3MB를 초과할 수 없습니다.")
         MultipartFile image
 
 ) {}

--- a/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
+++ b/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
@@ -47,10 +47,11 @@ public class GroupMemberService {
         // nickname 이 null이면 member의 name을 사용
         String nickname = groupJoinRequest.nickname() == null ? member.getName() : groupJoinRequest.nickname();
 
-        // TODO: 프로필 이미지 필드 추가
         GroupMember groupMember = GroupMember.builder()
                                              .nickname(nickname)
                                              .member(member)
+                                             // TODO: 기본 프로필 이미지 URL로 변경
+                                             .memberProfileImageUrl(member.getProfileImageUrl())
                                              .group(group)
                                              .build();
         return saveGroupMember(groupMember, group);

--- a/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
+++ b/src/main/java/com/midasdev/mybg/group_member/service/GroupMemberService.java
@@ -2,6 +2,7 @@ package com.midasdev.mybg.group_member.service;
 
 import com.midasdev.mybg.global.exception.ApplicationException;
 import com.midasdev.mybg.global.exception.ApplicationExceptionType;
+import com.midasdev.mybg.global.s3.S3Directory;
 import com.midasdev.mybg.global.s3.S3ImageService;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.domain.GroupStatistics;
@@ -94,7 +95,7 @@ public class GroupMemberService {
         // 4. 이미지 업데이트
         MultipartFile image = request.image();
         if (image != null && !image.isEmpty()) {
-            String imageUrl = s3ImageService.upload(image, "group-member-profile-image");
+            String imageUrl = s3ImageService.upload(image, S3Directory.GROUP_MEMBER_PROFILE_IMAGES);
             // TODO: 트랜젝션 롤백시 S3 이미지 삭제 배치 작업 필요
             groupMember.updateProfileImageUrl(imageUrl);
         }


### PR DESCRIPTION
# 🔍 Summary
그룹 정보 수정 API 구현

# 📑 Description
- 그룹 이름, 그룹 프로필 사진, 최대 인원 수 를 수정할 수 있는 API
- 그룹 Owner만 변경 가능

# 🔗 Related Issues
- #17 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정