### PR TITLE
그룹 번개 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 HELP.md
 .gradle
 build/
+
+# Prompt files
+prompt/
+prompt-*.md
+
+
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
@@ -7,6 +7,7 @@ import com.midasdev.mybg.bungae.controller.dto.request.GetMyBungaesRequest;
 import com.midasdev.mybg.bungae.controller.dto.request.GetGroupBungaesRequest;
 import com.midasdev.mybg.bungae.controller.dto.response.BungaeResponse;
 import com.midasdev.mybg.bungae.domain.Bungae;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.bungae.service.BungaeService;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.member.domain.Member;
@@ -99,7 +100,7 @@ public class BungaeController {
             @Valid GetGroupBungaesRequest request
     ) {
         CursorPage<BungaeDto> bungaes = bungaeService.findBungaesByGroupIdAndStatuses(
-                request.getGroupId(), request.getStatuses(), request.toPageable()
+                member, request.getGroupId(), request.getStatuses(), request.toPageable()
         );
         CursorPage<BungaeResponse> responses = bungaes.map(BungaeResponse::from);
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
@@ -4,6 +4,7 @@ import static com.midasdev.mybg.config.swagger.SwaggerConfig.SECURITY_SCHEME_NAM
 
 import com.midasdev.mybg.bungae.controller.dto.request.BungaeCreateRequest;
 import com.midasdev.mybg.bungae.controller.dto.request.GetMyBungaesRequest;
+import com.midasdev.mybg.bungae.controller.dto.request.GetGroupBungaesRequest;
 import com.midasdev.mybg.bungae.controller.dto.response.BungaeResponse;
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.service.BungaeService;
@@ -78,5 +79,30 @@ public class BungaeController {
         return ResponseEntity.ok(responses);
     }
 
+    @Operation(
+            summary = "그룹별 번개모임 목록 조회 API",
+            description = """
+                    특정 그룹의 번개모임 목록을 조회합니다.
+                    커서 페이지네이션을 지원합니다.
+                    - Request DTO : GetGroupBungaesRequest
+                    - Response DTO : CursorPage<BungaeResponse>
+                    - 세부사항:
+                        1. groupId는 필수 파라미터입니다.
+                        2. statuses가 null인 경우, 모든 상태의 번개를 조회합니다.
+                        3. 가장 마지막 번개가 포함되어 있을 경우, nextCursorId가 null이고 hasNext가 false로 반환됩니다.
+                    """,
+            security = @SecurityRequirement(name = SECURITY_SCHEME_NAME)
+    )
+    @GetMapping(value = "/group")
+    public ResponseEntity<CursorPage<BungaeResponse>> getGroupBungaes(
+            @AuthenticationPrincipal Member member,
+            @Valid GetGroupBungaesRequest request
+    ) {
+        CursorPage<BungaeDto> bungaes = bungaeService.findBungaesByGroupIdAndStatuses(
+                request.getGroupId(), request.getStatuses(), request.toPageable()
+        );
+        CursorPage<BungaeResponse> responses = bungaes.map(BungaeResponse::from);
+        return ResponseEntity.ok(responses);
+    }
 
 }

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/GetGroupBungaesRequest.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/GetGroupBungaesRequest.java
@@ -1,0 +1,49 @@
+package com.midasdev.mybg.bungae.controller.dto.request;
+
+import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.global.util.cursor_page.CursorPageRequest;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springdoc.core.annotations.ParameterObject;
+
+@ParameterObject
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class GetGroupBungaesRequest extends CursorPageRequest {
+
+    @Parameter(
+            description = "조회할 그룹 ID",
+            required = true,
+            example = "1"
+    )
+    @NotNull
+    @Positive
+    private Long groupId;
+
+    @Parameter(
+            description = """
+                    조회할 번개 상태 목록 (default: 모든 상태)
+                    - null인 경우, 모든 상태의 번개를 조회합니다.
+                    - 여러 상태를 지정할 수 있습니다.
+                    """,
+            example = "[\"RECRUITING\", \"CONFIRMED\"]",
+            array = @ArraySchema(
+                    schema = @Schema(
+                            implementation = BungaeStatus.class
+                    )
+            )
+    )
+    private List<BungaeStatus> statuses;
+
+}

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/GetGroupBungaesRequest.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/GetGroupBungaesRequest.java
@@ -37,7 +37,7 @@ public class GetGroupBungaesRequest extends CursorPageRequest {
                     - null인 경우, 모든 상태의 번개를 조회합니다.
                     - 여러 상태를 지정할 수 있습니다.
                     """,
-            example = "[\"RECRUITING\", \"CONFIRMED\"]",
+            example = "[\"RECRUITING\", \"CLOSED\"]",
             array = @ArraySchema(
                     schema = @Schema(
                             implementation = BungaeStatus.class

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
@@ -2,6 +2,7 @@ package com.midasdev.mybg.bungae.controller.dto.response;
 
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -23,7 +24,7 @@ public record BungaeResponse(
         BungaeStatus status,
         Long groupId,
         Long hostGroupMemberId,
-        LocalDateTime createdAt // [copilot] 번개가 만들어진 시간 정보 추가
+        LocalDateTime createdAt
 ) {
 
     public static BungaeResponse from(Bungae bungae) {
@@ -41,7 +42,27 @@ public record BungaeResponse(
                              .status(bungae.getStatus())
                              .groupId(bungae.getGroup().getId())
                              .hostGroupMemberId(bungae.getHost().getId())
-                             .createdAt(bungae.getAudit().getCreatedAt()) // [copilot] 번개 생성 시간 추가
+                             .createdAt(bungae.getAudit().getCreatedAt())
+                             .build();
+    }
+
+    public static BungaeResponse from(BungaeDto bungaeDto) {
+        return BungaeResponse.builder()
+                             .id(bungaeDto.id())
+                             .name(bungaeDto.name())
+                             .description(bungaeDto.description())
+                             .minAttendees(bungaeDto.minAttendees())
+                             .maxAttendees(bungaeDto.maxAttendees())
+                             .attendeeCount(bungaeDto.attendeeCount())
+                             .isOnline(bungaeDto.isOnline())
+                             .location(bungaeDto.location())
+                             .bungaeDate(bungaeDto.bungaeDateTime().getDate())
+                             .bungaeTime(bungaeDto.bungaeDateTime().getTime())
+                             .dateVoteClosedAt(bungaeDto.dateVoteClosedAt())
+                             .status(bungaeDto.status())
+                             .groupId(bungaeDto.groupId())
+                             .hostGroupMemberId(bungaeDto.hostGroupMemberId())
+                             .createdAt(bungaeDto.audit().getCreatedAt())
                              .build();
     }
 

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
@@ -62,7 +62,7 @@ public record BungaeResponse(
                              .status(bungaeDto.status())
                              .groupId(bungaeDto.groupId())
                              .hostGroupMemberId(bungaeDto.hostGroupMemberId())
-                             .createdAt(bungaeDto.audit().getCreatedAt())
+                             .createdAt(bungaeDto.createdAt())
                              .build();
     }
 

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
@@ -14,6 +14,7 @@ public record BungaeResponse(
         String description,
         Integer minAttendees,
         Integer maxAttendees,
+        Integer attendeeCount,
         Boolean isOnline,
         String location,
         LocalDate bungaeDate,
@@ -21,7 +22,8 @@ public record BungaeResponse(
         LocalDateTime dateVoteClosedAt,
         BungaeStatus status,
         Long groupId,
-        Long hostGroupMemberId
+        Long hostGroupMemberId,
+        LocalDateTime createdAt // [copilot] 번개가 만들어진 시간 정보 추가
 ) {
 
     public static BungaeResponse from(Bungae bungae) {
@@ -39,8 +41,8 @@ public record BungaeResponse(
                              .status(bungae.getStatus())
                              .groupId(bungae.getGroup().getId())
                              .hostGroupMemberId(bungae.getHost().getId())
+                             .createdAt(bungae.getAudit().getCreatedAt()) // [copilot] 번개 생성 시간 추가
                              .build();
     }
 
 }
-

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
@@ -3,6 +3,7 @@ package com.midasdev.mybg.bungae.controller.dto.response;
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
+import com.midasdev.mybg.global.util.cursor_page.LongIdentifiable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -25,7 +26,7 @@ public record BungaeResponse(
         Long groupId,
         Long hostGroupMemberId,
         LocalDateTime createdAt
-) {
+) implements LongIdentifiable {
 
     public static BungaeResponse from(Bungae bungae) {
         return BungaeResponse.builder()
@@ -64,6 +65,11 @@ public record BungaeResponse(
                              .hostGroupMemberId(bungaeDto.hostGroupMemberId())
                              .createdAt(bungaeDto.createdAt())
                              .build();
+    }
+
+    @Override
+    public Long getId() {
+        return id;
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/bungae/domain/Bungae.java
+++ b/src/main/java/com/midasdev/mybg/bungae/domain/Bungae.java
@@ -1,6 +1,7 @@
 package com.midasdev.mybg.bungae.domain;
 
 import com.midasdev.mybg.global.audit.Audit;
+import com.midasdev.mybg.global.util.cursor_page.LongIdentifiable;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group_member.domain.GroupMember;
 import jakarta.persistence.Column;
@@ -16,7 +17,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,7 +32,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Bungae {
+public class Bungae implements LongIdentifiable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/midasdev/mybg/bungae/domain/Bungae.java
+++ b/src/main/java/com/midasdev/mybg/bungae/domain/Bungae.java
@@ -80,7 +80,7 @@ public class Bungae implements LongIdentifiable {
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_member_id", nullable = false)
+    @JoinColumn(name = "host_group_member_id", nullable = false)
     private GroupMember host;
 
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepository.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepository.java
@@ -2,6 +2,7 @@ package com.midasdev.mybg.bungae.repository;
 
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
 import java.util.List;
@@ -9,8 +10,11 @@ import java.util.List;
 public interface CustomBungaeRepository {
 
     CursorPage<Bungae> findAllByAttendeeMemberIdAndStatusIn(
-        Long memberId,
-        List<BungaeStatus> statuses,
-        CursorPageable cursorPageable
+            Long memberId,
+            List<BungaeStatus> statuses,
+            CursorPageable cursorPageable
     );
+
+    CursorPage<BungaeDto> findByGroupIdAndStatusIn(Long groupId, List<BungaeStatus> statuses, CursorPageable pageable);
+
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -4,9 +4,13 @@ import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.domain.QBungae;
 import com.midasdev.mybg.bungae.domain.QBungaeAttendee;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
+import com.midasdev.mybg.bungae.repository.dto.QBungaeDto;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +58,69 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
     private BooleanExpression createMemberAndBungaeStatusCondition(Long memberId, List<BungaeStatus> statuses) {
         BooleanExpression baseCondition = attendee.groupMember.member.id.eq(memberId)
                 .and(attendee.deleted.isFalse())
+                .and(bungae.deleted.isFalse());
+
+        BooleanExpression statusCondition = (statuses == null || statuses.isEmpty())
+                ? null
+                : bungae.status.in(statuses);
+
+        return (statusCondition == null)
+                ? baseCondition
+                : baseCondition.and(statusCondition);
+    }
+
+    @Override
+    public CursorPage<BungaeDto> findByGroupIdAndStatusIn(Long groupId, List<BungaeStatus> statuses, CursorPageable cursorPageable) {
+        Long cursorId = cursorPageable.lastCursorId();
+        int pageSize = cursorPageable.pageSize();
+
+        BooleanExpression condition = createGroupAndBungaeStatusCondition(groupId, statuses)
+            .and(cursorId != null ? bungae.id.lt(cursorId) : null);
+
+        JPQLQuery<Integer> attendeeCount = JPAExpressions
+                .select(attendee.count().intValue())
+                .from(attendee)
+                .where(attendee.bungae.eq(bungae)
+                                      .and(attendee.deleted.isFalse()));
+
+        List<BungaeDto> content = queryFactory
+                .select(new QBungaeDto(
+                        bungae.id,
+                        bungae.name,
+                        bungae.description,
+                        bungae.minAttendees,
+                        bungae.maxAttendees,
+                        bungae.isOnline,
+                        bungae.location,
+                        bungae.bungaeDateTime,
+                        bungae.dateVoteClosedAt,
+                        bungae.status,
+                        bungae.audit,
+                        bungae.deleted,
+                        bungae.group.id,
+                        bungae.host.id,
+                        attendeeCount
+                ))
+                .from(bungae)
+                .join(bungae.group)
+                .join(bungae.host)
+                .where(condition) // 그룹 ID, 상태 조건, last cursor ID 조건
+                .orderBy(bungae.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = content.size() > pageSize;
+        Long nextCursorId = null;
+        if (hasNext) {
+            content.remove(pageSize);
+            nextCursorId = content.get(pageSize - 1).id();
+        }
+
+        return new CursorPage<>(content, nextCursorId, hasNext);
+    }
+
+    private BooleanExpression createGroupAndBungaeStatusCondition(Long groupId, List<BungaeStatus> statuses) {
+        BooleanExpression baseCondition = bungae.group.id.eq(groupId)
                 .and(bungae.deleted.isFalse());
 
         BooleanExpression statusCondition = (statuses == null || statuses.isEmpty())

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -95,7 +95,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                         bungae.bungaeDateTime,
                         bungae.dateVoteClosedAt,
                         bungae.status,
-                        bungae.audit,
+                        bungae.audit.createdAt,
                         bungae.deleted,
                         bungae.group.id,
                         bungae.host.id,

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.midasdev.mybg.bungae.repository.dto.QBungaeDto;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -31,10 +32,14 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
         Long cursorId = cursorPageable.lastCursorId();
         int pageSize = cursorPageable.pageSize();
 
-        BooleanExpression condition = createMemberAndBungaeStatusCondition(memberId, statuses)
-            .and(cursorId != null ? bungae.id.lt(cursorId) : null); // 내림차순 정렬이므로 lt
+        BooleanExpression condition = Expressions.allOf(
+                attendee.groupMember.member.id.eq(memberId)
+                                              .and(attendee.deleted.isFalse())
+                                              .and(bungae.deleted.isFalse()),
+                bungaeStatuesAndCursorCondition(cursorId, statuses)
+        );
 
-        List<Bungae> content = queryFactory
+        List<Bungae> fetchedContent = queryFactory
                 .selectFrom(bungae)
                 .join(attendee).on(attendee.bungae.eq(bungae))
                 .fetchJoin()
@@ -42,31 +47,10 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 .join(bungae.host).fetchJoin()
                 .where(condition)
                 .orderBy(bungae.id.desc()) // id 기준 내림차순 정렬 (최신순)
-                .limit(pageSize + 1)
+                .limit(cursorPageable.getFetchSize())
                 .fetch();
 
-        boolean hasNext = content.size() > pageSize;
-        Long nextCursorId = null;
-        if (hasNext) {
-            content.remove(pageSize); // 페이지 크기보다 하나 더 가져왔으므로 마지막 요소 제거
-            nextCursorId = content.get(pageSize - 1).getId(); // 다음 페이지의 커서 ID는 현재 페이지의 마지막 요소
-        }
-
-        return new CursorPage<>(content, nextCursorId, hasNext);
-    }
-
-    private BooleanExpression createMemberAndBungaeStatusCondition(Long memberId, List<BungaeStatus> statuses) {
-        BooleanExpression baseCondition = attendee.groupMember.member.id.eq(memberId)
-                .and(attendee.deleted.isFalse())
-                .and(bungae.deleted.isFalse());
-
-        BooleanExpression statusCondition = (statuses == null || statuses.isEmpty())
-                ? null
-                : bungae.status.in(statuses);
-
-        return (statusCondition == null)
-                ? baseCondition
-                : baseCondition.and(statusCondition);
+        return new CursorPage<>(fetchedContent, pageSize);
     }
 
     @Override
@@ -74,8 +58,11 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
         Long cursorId = cursorPageable.lastCursorId();
         int pageSize = cursorPageable.pageSize();
 
-        BooleanExpression condition = createGroupAndBungaeStatusCondition(groupId, statuses)
-            .and(cursorId != null ? bungae.id.lt(cursorId) : null);
+        BooleanExpression condition = Expressions.allOf(
+                bungae.group.id.eq(groupId)
+                               .and(bungae.deleted.isFalse()),
+                bungaeStatuesAndCursorCondition(cursorId, statuses)
+        );
 
         JPQLQuery<Integer> attendeeCount = JPAExpressions
                 .select(attendee.count().intValue())
@@ -83,7 +70,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 .where(attendee.bungae.eq(bungae)
                                       .and(attendee.deleted.isFalse()));
 
-        List<BungaeDto> content = queryFactory
+        List<BungaeDto> fetchedContent = queryFactory
                 .select(new QBungaeDto(
                         bungae.id,
                         bungae.name,
@@ -106,29 +93,21 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 .join(bungae.host)
                 .where(condition) // 그룹 ID, 상태 조건, last cursor ID 조건
                 .orderBy(bungae.id.desc())
-                .limit(pageSize + 1)
+                .limit(cursorPageable.getFetchSize())
                 .fetch();
 
-        boolean hasNext = content.size() > pageSize;
-        Long nextCursorId = null;
-        if (hasNext) {
-            content.remove(pageSize);
-            nextCursorId = content.get(pageSize - 1).id();
-        }
-
-        return new CursorPage<>(content, nextCursorId, hasNext);
+        return new CursorPage<>(fetchedContent, pageSize);
     }
 
-    private BooleanExpression createGroupAndBungaeStatusCondition(Long groupId, List<BungaeStatus> statuses) {
-        BooleanExpression baseCondition = bungae.group.id.eq(groupId)
-                .and(bungae.deleted.isFalse());
-
+    private BooleanExpression bungaeStatuesAndCursorCondition(Long cursorId, List<BungaeStatus> statuses) {
         BooleanExpression statusCondition = (statuses == null || statuses.isEmpty())
                 ? null
                 : bungae.status.in(statuses);
 
-        return (statusCondition == null)
-                ? baseCondition
-                : baseCondition.and(statusCondition);
+        return Expressions.allOf(
+                statusCondition,
+                cursorId != null ? bungae.id.lt(cursorId) : null
+        );
     }
+
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
@@ -2,7 +2,6 @@ package com.midasdev.mybg.bungae.repository.dto;
 
 import com.midasdev.mybg.bungae.domain.BungaeDateTime;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
-import com.midasdev.mybg.global.audit.Audit;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 
@@ -17,7 +16,7 @@ public record BungaeDto(
         BungaeDateTime bungaeDateTime,
         LocalDateTime dateVoteClosedAt,
         BungaeStatus status,
-        Audit audit,
+        LocalDateTime createdAt,
         Boolean deleted,
         Long groupId,
         Long hostGroupMemberId,

--- a/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
@@ -2,6 +2,7 @@ package com.midasdev.mybg.bungae.repository.dto;
 
 import com.midasdev.mybg.bungae.domain.BungaeDateTime;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.global.util.cursor_page.LongIdentifiable;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 
@@ -21,10 +22,15 @@ public record BungaeDto(
         Long groupId,
         Long hostGroupMemberId,
         Integer attendeeCount
-) {
+) implements LongIdentifiable {
 
     @QueryProjection
     public BungaeDto {
+    }
+
+    @Override
+    public Long getId() {
+        return id;
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
@@ -1,0 +1,31 @@
+package com.midasdev.mybg.bungae.repository.dto;
+
+import com.midasdev.mybg.bungae.domain.BungaeDateTime;
+import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.global.audit.Audit;
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+
+public record BungaeDto(
+        Long id,
+        String name,
+        String description,
+        Integer minAttendees,
+        Integer maxAttendees,
+        Boolean isOnline,
+        String location,
+        BungaeDateTime bungaeDateTime,
+        LocalDateTime dateVoteClosedAt,
+        BungaeStatus status,
+        Audit audit,
+        Boolean deleted,
+        Long groupId,
+        Long hostGroupMemberId,
+        Integer attendeeCount
+) {
+
+    @QueryProjection
+    public BungaeDto {
+    }
+
+}

--- a/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
+++ b/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
@@ -6,6 +6,7 @@ import com.midasdev.mybg.bungae.domain.BungaeAttendee;
 import com.midasdev.mybg.bungae.domain.BungaeDateTime;
 import com.midasdev.mybg.bungae.domain.BungaeRecruitDateOption;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.bungae.repository.BungaeAttendeeRepository;
 import com.midasdev.mybg.bungae.repository.BungaeRecruitDateOptionRepository;
 import com.midasdev.mybg.bungae.repository.BungaeRepository;
@@ -14,6 +15,8 @@ import com.midasdev.mybg.global.exception.ApplicationException;
 import com.midasdev.mybg.global.exception.ApplicationExceptionType;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
+import com.midasdev.mybg.group.domain.Group;
+import com.midasdev.mybg.group.repository.GroupRepository;
 import com.midasdev.mybg.group_member.domain.GroupMember;
 import com.midasdev.mybg.group_member.repository.GroupMemberRepository;
 import com.midasdev.mybg.member.domain.Member;
@@ -32,10 +35,12 @@ public class BungaeService {
     private final BungaeRecruitDateOptionRepository bungaeRecruitDateOptionRepository;
     private final BungaeAttendeeRepository bungaeAttendeeRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final GroupRepository groupRepository;
 
     @Transactional
     public Bungae createBungae(BungaeCreateRequest request) {
         // 1. groupId와 groupMemberId로 삭제되지 않은 groupMember 조회 (그룹에 속하는 그룹멤버가 없다면 예외)
+        // TODO: hostGroupMember는 요청을 보낸 사람이므로, member 정보를 통해 그룹멤버를 조회하는 로직으로 변경 필요
         GroupMember hostGroupMember = groupMemberRepository.findByIdAndGroupIdAndDeletedFalse(request.hostGroupMemberId(), request.groupId())
                                                            .orElseThrow(() -> new ApplicationException(
                                                                    ApplicationExceptionType.GROUP_MEMBER_NOT_FOUND_BY_GROUP_ID,
@@ -110,6 +115,20 @@ public class BungaeService {
             CursorPageable cursorPageable
     ) {
         return bungaeRepository.findAllByAttendeeMemberIdAndStatusIn(member.getId(), statuses, cursorPageable);
+    }
+
+    public CursorPage<BungaeDto> findBungaesByGroupIdAndStatuses(Member member, Long groupId, List<BungaeStatus> statuses, CursorPageable pageable) {
+        // 1. 그룹 존재 여부 검증
+        Group group = groupRepository.findByIdAndDeletedIsFalse(groupId)
+                                    .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_NOT_FOUND_BY_ID, groupId));
+
+        // 2. 멤버가 그룹에 속하는지 검증
+        groupMemberRepository.findByMemberAndGroup(member, group)
+                             .orElseThrow(() -> new ApplicationException(ApplicationExceptionType.GROUP_MEMBER_NOT_FOUND_BY_GROUP_ID, member.getId(), groupId));
+
+        // 3. 해당 그룹에 속하고 statuses에 포함된 번개모임 조회
+        return bungaeRepository.findByGroupIdAndStatusIn(groupId, statuses, pageable);
+
     }
 
 }

--- a/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPage.java
+++ b/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPage.java
@@ -1,20 +1,50 @@
 package com.midasdev.mybg.global.util.cursor_page;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
+@Builder
 @RequiredArgsConstructor
-public class CursorPage<T> {
+public class CursorPage<T extends LongIdentifiable> {
     private final List<T> content;
     private final Long nextCursorId;
+    private final Integer pageSize;
     private final boolean hasNext;
 
-    public <R> CursorPage<R> map(Function<? super T, ? extends R> mapper) {
+    /**
+     * @param fetchedContent pageSize+1의 limit을 적용하여 가져온 데이터
+     * @param pageSize
+     */
+    public CursorPage(List<T> fetchedContent, int pageSize) {
+        if (fetchedContent.size() > pageSize + 1) {
+            throw new IllegalArgumentException(String.format("Invalid fetchedContent size: expected at most %d (pageSize + 1), but got %d",
+                                                             pageSize + 1, fetchedContent.size()));
+        }
+
+        this.pageSize = pageSize;
+        this.hasNext = fetchedContent.size() > pageSize;
+        if (hasNext) {
+            this.nextCursorId = fetchedContent.get(pageSize - 1).getId();
+            fetchedContent.remove(pageSize);
+        } else {
+            this.nextCursorId = null;
+        }
+        this.content = Collections.unmodifiableList(fetchedContent);
+    }
+
+    public <R extends LongIdentifiable> CursorPage<R> map(Function<? super T, ? extends R> mapper) {
         List<R> mappedContent = content.stream().map(mapper).collect(Collectors.toList());
-        return new CursorPage<>(mappedContent, nextCursorId, hasNext);
+        return CursorPage.<R>builder()
+                .content(mappedContent)
+                .nextCursorId(nextCursorId)
+                .pageSize(pageSize)
+                .hasNext(hasNext)
+                .build();
     }
 }

--- a/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPage.java
+++ b/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPage.java
@@ -1,6 +1,5 @@
 package com.midasdev.mybg.global.util.cursor_page;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,11 +30,11 @@ public class CursorPage<T extends LongIdentifiable> {
         this.hasNext = fetchedContent.size() > pageSize;
         if (hasNext) {
             this.nextCursorId = fetchedContent.get(pageSize - 1).getId();
-            fetchedContent.remove(pageSize);
+            this.content = List.copyOf(fetchedContent.subList(0, pageSize));
         } else {
             this.nextCursorId = null;
+            this.content = List.copyOf(fetchedContent);
         }
-        this.content = Collections.unmodifiableList(fetchedContent);
     }
 
     public <R extends LongIdentifiable> CursorPage<R> map(Function<? super T, ? extends R> mapper) {

--- a/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPageable.java
+++ b/src/main/java/com/midasdev/mybg/global/util/cursor_page/CursorPageable.java
@@ -19,4 +19,11 @@ public record CursorPageable(
     public CursorPageable(Long lastCursorId, Integer pageSize) {
         this(lastCursorId, pageSize, SortOrder.ASC);
     }
+
+    /**
+     * 지정된 pageSize 다음 리소스가 있는지 확인하기 위해, pageSize + 1 만큼 데이터를 가져오도록 fetchSize를 설정합니다.
+     */
+    public int getFetchSize() {
+        return pageSize + 1;
+    }
 }

--- a/src/main/java/com/midasdev/mybg/global/util/cursor_page/LongIdentifiable.java
+++ b/src/main/java/com/midasdev/mybg/global/util/cursor_page/LongIdentifiable.java
@@ -1,0 +1,5 @@
+package com.midasdev.mybg.global.util.cursor_page;
+
+public interface LongIdentifiable {
+    Long getId();
+}

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -21,6 +21,7 @@ import com.midasdev.mybg.member.fixture.MemberFixture;
 import com.midasdev.mybg.member.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,8 +34,8 @@ import org.springframework.context.annotation.Import;
  * - Member: member, otherMember
  * - Group: group, otherGroup
  * - GroupMember:
- *     * group : groupMember (member가 group에 참여자로 등록된 상태)
- *     * otherGroup : otherGroupMember(otherMember), memberInOtherGroup(member)
+ * * group : groupMember (member가 group에 참여자로 등록된 상태)
+ * * otherGroup : otherGroupMember(otherMember), memberInOtherGroup(member)
  * - Bungae: savedBungaes (group에서 member가 참여자로 등록된, 각각의 상태를 가지는 번개들), otherMemberSavedBungaes (otherGroup에서 otherMember가 참여자로 등록된, 각각의 상태를 가지는 번개들)
  * + member가 otherGroup의 RECRUITING, CLOSED 번개에도 참여
  */
@@ -64,8 +65,7 @@ class CustomBungaeRepositoryTest {
     private GroupMember otherGroupMember;
     private GroupMember memberInOtherGroup;
     private List<Bungae> groupSavedBungaes;
-    private List<Bungae> otherGroupSavedBungaes;
-
+    private List<Long> memberJoinedBungaeIds;
 
     @BeforeEach
     void setUp() {
@@ -80,66 +80,57 @@ class CustomBungaeRepositoryTest {
 
         // 각 BungaeStatus별로 Bungae 생성 및 저장
         groupSavedBungaes = new ArrayList<>();
-        otherGroupSavedBungaes = new ArrayList<>();
+        memberJoinedBungaeIds = new ArrayList<>();
 
-        // DATE_VOTING 번개 생성
-        Bungae dateVotingBungae = bungaeRepository.save(
-                BungaeFixture.createWithDateVoting(group, groupMember));
-        groupSavedBungaes.add(dateVotingBungae);
-        // DATE_VOTING 번개 생성 (다른 그룹 멤버)
-        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithDateVoting(otherGroup, otherGroupMember)));
+        // 각 상태별 번개 생성 및 참여자 등록 - group
+        createBungaeAndSaveAttendee(BungaeFixture::createWithDateVoting, group, groupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithRecruitingClosed, group, groupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithClosed, group, groupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithCancelled, group, groupMember);
 
-        // RECRUITING 번개 생성
-        Bungae recruitingBungae = bungaeRepository.save(
-                BungaeFixture.createWithRecruiting(group, groupMember));
-        groupSavedBungaes.add(recruitingBungae);
-        // RECRUITING 번개 생성 (다른 그룹 멤버)
-        Bungae otherRecruitingBungae = bungaeRepository.save(BungaeFixture.createWithRecruiting(otherGroup, otherGroupMember));
-        otherGroupSavedBungaes.add(otherRecruitingBungae);
-
-        // RECRUITING_CLOSED 번개 생성
-        Bungae recruitingClosedBungae = bungaeRepository.save(
-                BungaeFixture.createWithRecruitingClosed(group, groupMember));
-        groupSavedBungaes.add(recruitingClosedBungae);
-        // RECRUITING_CLOSED 번개 생성 (다른 그룹 멤버)
-        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruitingClosed(otherGroup, otherGroupMember)));
-
-        // CLOSED 번개 생성
-        Bungae closedBungae = bungaeRepository.save(
-                BungaeFixture.createWithClosed(group, groupMember));
-        groupSavedBungaes.add(closedBungae);
-        // CLOSED 번개 생성 (다른 그룹 멤버)
-        Bungae otherClosedBungae = bungaeRepository.save(BungaeFixture.createWithClosed(otherGroup, otherGroupMember));
-        otherGroupSavedBungaes.add(otherClosedBungae);
-
-        // CANCELLED 번개 생성
-        Bungae cancelledBungae = bungaeRepository.save(
-                BungaeFixture.createWithCancelled(group, groupMember));
-        groupSavedBungaes.add(cancelledBungae);
-        // CANCELLED 번개 생성 (다른 그룹 멤버)
-        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithCancelled(otherGroup, otherGroupMember)));
-
-        // 각 번개에 대해 BungaeAttendee 생성 (member가 참여자로 등록)
-        saveAttendee(groupSavedBungaes, groupMember);
-        saveAttendee(otherGroupSavedBungaes, otherGroupMember);
-
-        //  member를 otherGroup의 RECRUITING, CLOSED 번개에 참여자로 추가
-        saveAttendeeForMemberInOtherGroup(otherRecruitingBungae, memberInOtherGroup);
-        saveAttendeeForMemberInOtherGroup(otherClosedBungae, memberInOtherGroup);
+        //  각 상태별 번개 생성 및 참여자 등록 - otherGroup
+        createBungaeAndSaveAttendee(BungaeFixture::createWithDateVoting, otherGroup, otherGroupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, otherGroup, otherGroupMember, memberInOtherGroup);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithRecruitingClosed, otherGroup, otherGroupMember);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithClosed, otherGroup, otherGroupMember, memberInOtherGroup);
+        createBungaeAndSaveAttendee(BungaeFixture::createWithCancelled, otherGroup, otherGroupMember);
     }
 
-    private void saveAttendee(List<Bungae> bungaes, GroupMember groupMember) {
-        for (Bungae bungae : bungaes) {
-            BungaeAttendee attendee = BungaeAttendee.builder()
-                                                    .bungae(bungae)
-                                                    .groupMember(groupMember)
-                                                    .deleted(false)
-                                                    .build();
-            bungaeAttendeeRepository.save(attendee);
+    /**
+     * 번개 생성과 참여자 저장을 통합한 헬퍼 메서드
+     */
+    private void createBungaeAndSaveAttendee(
+            BiFunction<Group, GroupMember, Bungae> bungaeCreator,
+            Group group,
+            GroupMember host,
+            GroupMember... additionalAttendees
+    ) {
+        Bungae bungae = bungaeRepository.save(bungaeCreator.apply(group, host));
+
+        if (group.getId().equals(this.group.getId())) {
+            groupSavedBungaes.add(bungae);
         }
+
+        saveAttendee(bungae, host);
+
+        // host가 member인 경우 memberJoinedBungaeIds에 추가
+        if (host.getMember().getId().equals(member.getId())) {
+            memberJoinedBungaeIds.add(bungae.getId());
+        }
+
+        for (GroupMember attendee : additionalAttendees) {
+            saveAttendee(bungae, attendee);
+
+            // 추가 참여자가 member인 경우 memberJoinedBungaeIds에 추가
+            if (attendee.getMember().getId().equals(member.getId())) {
+                memberJoinedBungaeIds.add(bungae.getId());
+            }
+        }
+
     }
 
-    private void saveAttendeeForMemberInOtherGroup(Bungae bungae, GroupMember groupMember) {
+    private void saveAttendee(Bungae bungae, GroupMember groupMember) {
         BungaeAttendee attendee = BungaeAttendee.builder()
                                                 .bungae(bungae)
                                                 .groupMember(groupMember)
@@ -149,7 +140,7 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("lastCursorId, size 조건에 맞는 번개만 조회된다")
+    @DisplayName("B-2-R-1: 조건에 맞는 올바른 나의 번개 조회 - lastCursorId, size")
     void findAllByAttendeeMemberIdAndStatusIn_withCursorAndSize_shouldReturnCorrectBungaes() {
         // given
         Long lastCursorId = Long.MAX_VALUE;
@@ -167,11 +158,12 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent()).hasSize(pageSize);
         assertThat(result.getContent())
                 .extracting(Bungae::getId)
-                .allMatch(id -> id < lastCursorId); // cursor보다 작은 ID만 조회되어야 함
+                .allMatch(id -> id < lastCursorId)
+                .allMatch(memberJoinedBungaeIds::contains);
     }
 
     @Test
-    @DisplayName("특정 status 조건에 맞는 번개만 조회된다")
+    @DisplayName("B-2-R-2: 조건에 맞는 올바른 나의 번개 조회 - status")
     void findAllByAttendeeMemberIdAndStatusIn_withStatus_shouldReturnFilteredBungaes() {
         // given
         List<BungaeStatus> targetStatuses = List.of(BungaeStatus.DATE_VOTING, BungaeStatus.RECRUITING);
@@ -187,12 +179,15 @@ class CustomBungaeRepositoryTest {
         // then
         assertThat(result.getContent()).hasSize(3); // DATE_VOTING 1개 + RECRUITING 2개
         assertThat(result.getContent())
+                .extracting(Bungae::getId)
+                .allMatch(memberJoinedBungaeIds::contains);
+        assertThat(result.getContent())
                 .extracting(Bungae::getStatus)
                 .doesNotContain(BungaeStatus.RECRUITING_CLOSED, BungaeStatus.CLOSED, BungaeStatus.CANCELLED);
     }
 
     @Test
-    @DisplayName("status가 null일 경우 모든 상태의 번개가 조회된다")
+    @DisplayName("B-2-R-3: 조건에 맞는 올바른 나의 번개 조회 - status가 null일 경우")
     void findAllByAttendeeMemberIdAndStatusIn_withNullStatus_shouldReturnAllBungaes() {
         // given
         CursorPageable cursorPageable = new CursorPageable(null, 10);
@@ -205,8 +200,10 @@ class CustomBungaeRepositoryTest {
         );
 
         // then
-        // member가 참여한 번개: group의 5개 + otherGroup의 2개 (RECRUITING, CLOSED)
-        assertThat(result.getContent()).hasSize(7);
+        assertThat(result.getContent()).hasSize(memberJoinedBungaeIds.size()); // member가 참여한 모든 번개 수와 일치
+        assertThat(result.getContent())
+                .extracting(Bungae::getId)
+                .containsExactlyInAnyOrderElementsOf(memberJoinedBungaeIds); // member가 참여한 모든 번개 ID와 정확히 일치
         assertThat(result.getContent())
                 .extracting(Bungae::getStatus)
                 .contains(
@@ -219,7 +216,7 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("lastCursorId가 null일 경우 가장 최근 것부터 조회된다")
+    @DisplayName("B-2-R-4: lastCursorId가 null일 경우 가장 최근 것부터 나의 번개 조회")
     void findAllByAttendeeMemberIdAndStatusIn_withNullCursor_shouldReturnFromLatest() {
         // given
         CursorPageable cursorPageable = new CursorPageable(null, 3);
@@ -239,26 +236,17 @@ class CustomBungaeRepositoryTest {
                                      .map(Bungae::getId)
                                      .toList();
 
-        //  member가 참여한 모든 번개 중 최신 3개를 가져와서 검증
-        List<Long> allMemberBungaeIds = new ArrayList<>();
-        allMemberBungaeIds.addAll(groupSavedBungaes.stream().map(Bungae::getId).toList());
-        //  otherGroup의 번개 중 member가 참여하고 있는 RECRUITING, CLOSED 번개 ID 추가
-        allMemberBungaeIds.addAll(otherGroupSavedBungaes.stream()
-                                                        .filter(bungae -> bungae.getStatus() == BungaeStatus.RECRUITING
-                                                                || bungae.getStatus() == BungaeStatus.CLOSED)
-                                                        .map(Bungae::getId).toList());
+        // member가 참여한 번개 ID들을 내림차순으로 정렬하여 상위 3개와 비교
+        List<Long> expectedSortedIds = memberJoinedBungaeIds.stream()
+                                                            .sorted((a, b) -> Long.compare(b, a))
+                                                            .limit(3)
+                                                            .toList();
 
-        List<Long> sortedIds = allMemberBungaeIds.stream()
-                                                 .sorted((a, b) -> Long.compare(b, a))
-                                                 .limit(3)
-                                                 .toList();
-
-        assertThat(resultIds).isEqualTo(sortedIds);
-        assertThat(result.getNextCursorId()).isEqualTo(result.getContent().get(2).getId());
+        assertThat(resultIds).isEqualTo(expectedSortedIds);
     }
 
     @Test
-    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조회 - lastCursorId, size")
+    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조�� - lastCursorId, size")
     void findByGroupIdAndStatusIn_withCursorAndSize_shouldReturnCorrectBungaes() {
         // given
         Long lastCursorId = Long.MAX_VALUE;

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -17,7 +17,6 @@ import com.midasdev.mybg.member.fixture.MemberFixture;
 import com.midasdev.mybg.member.repository.MemberRepository;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
-import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,9 +33,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 공통 given
  * - Member: member, otherMember
  * - Group: group, otherGroup
- * - GroupMember: groupMember, otherGroupMember
+ * - GroupMember:
+ *     - group : groupMember (member가 group에 참여자로 등록된 상태)
+ *     - otherGroup : otherGroupMember(otherMember), memberInOtherGroup(member)
  * - Bungae: savedBungaes (group에서 member가 참여자로 등록된, 각각의 상태를 가지는 번개들),
  *           otherMemberSavedBungaes (otherGroup에서 otherMember가 참여자로 등록된, 각각의 상태를 가지는 번개들)
+ *           + member가 otherGroup의 RECRUITING, CLOSED 번개에도 참여
  */
 
 @DataJpaTest
@@ -62,8 +64,9 @@ class CustomBungaeRepositoryTest {
     private Group group, otherGroup;
     private GroupMember groupMember;
     private GroupMember otherGroupMember;
-    private List<Bungae> savedBungaes;
-    private List<Bungae> otherMemberSavedBungaes;
+    private GroupMember memberInOtherGroup;
+    private List<Bungae> groupSavedBungaes;
+    private List<Bungae> otherGroupSavedBungaes;
 
 
     @BeforeEach
@@ -75,53 +78,56 @@ class CustomBungaeRepositoryTest {
         otherGroup = groupRepository.save(GroupFixture.create(otherMember, "다른 그룹", "other-group-invitation-code"));
         groupMember = groupMemberRepository.save(GroupMemberFixture.create(group, member));
         otherGroupMember = groupMemberRepository.save(GroupMemberFixture.create(otherGroup, otherMember));
+        memberInOtherGroup = groupMemberRepository.save(GroupMemberFixture.create(otherGroup, member));
 
         // 각 BungaeStatus별로 Bungae 생성 및 저장
-        savedBungaes = new ArrayList<>();
-        otherMemberSavedBungaes = new ArrayList<>();
+        groupSavedBungaes = new ArrayList<>();
+        otherGroupSavedBungaes = new ArrayList<>();
 
         // DATE_VOTING 번개 생성
         Bungae dateVotingBungae = bungaeRepository.save(
                 BungaeFixture.createWithDateVoting(group, groupMember));
-        savedBungaes.add(dateVotingBungae);
-
+        groupSavedBungaes.add(dateVotingBungae);
         // DATE_VOTING 번개 생성 (다른 그룹 멤버)
-        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithDateVoting(otherGroup, otherGroupMember)));
-
+        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithDateVoting(otherGroup, otherGroupMember)));
 
         // RECRUITING 번개 생성
         Bungae recruitingBungae = bungaeRepository.save(
                 BungaeFixture.createWithRecruiting(group, groupMember));
-        savedBungaes.add(recruitingBungae);
-
+        groupSavedBungaes.add(recruitingBungae);
         // RECRUITING 번개 생성 (다른 그룹 멤버)
-        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruiting(otherGroup, otherGroupMember)));
-
+        Bungae otherRecruitingBungae = bungaeRepository.save(BungaeFixture.createWithRecruiting(otherGroup, otherGroupMember));
+        otherGroupSavedBungaes.add(otherRecruitingBungae);
 
         // RECRUITING_CLOSED 번개 생성
         Bungae recruitingClosedBungae = bungaeRepository.save(
                 BungaeFixture.createWithRecruitingClosed(group, groupMember));
-        savedBungaes.add(recruitingClosedBungae);
+        groupSavedBungaes.add(recruitingClosedBungae);
         // RECRUITING_CLOSED 번개 생성 (다른 그룹 멤버)
-        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruitingClosed(otherGroup, otherGroupMember)));
+        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruitingClosed(otherGroup, otherGroupMember)));
 
         // CLOSED 번개 생성
         Bungae closedBungae = bungaeRepository.save(
                 BungaeFixture.createWithClosed(group, groupMember));
-        savedBungaes.add(closedBungae);
+        groupSavedBungaes.add(closedBungae);
         // CLOSED 번개 생성 (다른 그룹 멤버)
-        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithClosed(otherGroup, otherGroupMember)));
+        Bungae otherClosedBungae = bungaeRepository.save(BungaeFixture.createWithClosed(otherGroup, otherGroupMember));
+        otherGroupSavedBungaes.add(otherClosedBungae);
 
         // CANCELLED 번개 생성
         Bungae cancelledBungae = bungaeRepository.save(
                 BungaeFixture.createWithCancelled(group, groupMember));
-        savedBungaes.add(cancelledBungae);
+        groupSavedBungaes.add(cancelledBungae);
         // CANCELLED 번개 생성 (다른 그룹 멤버)
-        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithCancelled(otherGroup, otherGroupMember)));
+        otherGroupSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithCancelled(otherGroup, otherGroupMember)));
 
         // 각 번개에 대해 BungaeAttendee 생성 (member가 참여자로 등록)
-        saveAttendee(savedBungaes, groupMember);
-        saveAttendee(otherMemberSavedBungaes, otherGroupMember);
+        saveAttendee(groupSavedBungaes, groupMember);
+        saveAttendee(otherGroupSavedBungaes, otherGroupMember);
+
+        //  member를 otherGroup의 RECRUITING, CLOSED 번개에 참여자로 추가
+        saveAttendeeForMemberInOtherGroup(otherRecruitingBungae, memberInOtherGroup);
+        saveAttendeeForMemberInOtherGroup(otherClosedBungae, memberInOtherGroup);
     }
 
     private void saveAttendee(List<Bungae> bungaes, GroupMember groupMember) {
@@ -135,18 +141,27 @@ class CustomBungaeRepositoryTest {
         }
     }
 
+    private void saveAttendeeForMemberInOtherGroup(Bungae bungae, GroupMember groupMember) {
+        BungaeAttendee attendee = BungaeAttendee.builder()
+                                                .bungae(bungae)
+                                                .groupMember(groupMember)
+                                                .deleted(false)
+                                                .build();
+        bungaeAttendeeRepository.save(attendee);
+    }
+
     @Test
     @DisplayName("lastCursorId, size 조건에 맞는 번개만 조회된다")
     void findAllByAttendeeMemberIdAndStatusIn_withCursorAndSize_shouldReturnCorrectBungaes() {
         // given
-        Long lastCursorId = Long.MAX_VALUE; // 마지막에 저장된 번개의 ID보다 큰 값
+        Long lastCursorId = Long.MAX_VALUE;
         int pageSize = 2;
         CursorPageable cursorPageable = new CursorPageable(lastCursorId, pageSize);
 
         // when
         CursorPage<Bungae> result = bungaeRepository.findAllByAttendeeMemberIdAndStatusIn(
                 member.getId(),
-                null, // 모든 상태
+                null,
                 cursorPageable
         );
 
@@ -155,10 +170,6 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent())
                 .extracting(Bungae::getId)
                 .allMatch(id -> id < lastCursorId); // cursor보다 작은 ID만 조회되어야 함
-        assertThat(result.isHasNext()).isTrue();
-        // nextCursorId는 반환된 마지막 요소의 ID여야 함
-        Long expectedNextCursorId = result.getContent().get(pageSize - 1).getId();
-        assertThat(result.getNextCursorId()).isEqualTo(expectedNextCursorId);
     }
 
     @Test
@@ -176,7 +187,7 @@ class CustomBungaeRepositoryTest {
         );
 
         // then
-        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).hasSize(3); // DATE_VOTING 1개 + RECRUITING 2개
         assertThat(result.getContent())
                 .extracting(Bungae::getStatus)
                 .doesNotContain(BungaeStatus.RECRUITING_CLOSED, BungaeStatus.CLOSED, BungaeStatus.CANCELLED);
@@ -191,15 +202,16 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<Bungae> result = bungaeRepository.findAllByAttendeeMemberIdAndStatusIn(
                 member.getId(),
-                null, // status가 null
+                null,
                 cursorPageable
         );
 
         // then
-        assertThat(result.getContent()).hasSize(5); // 모든 상태의 번개 5개 조회
+        // member가 참여한 번개: group의 5개 + otherGroup의 2개 (RECRUITING, CLOSED)
+        assertThat(result.getContent()).hasSize(7);
         assertThat(result.getContent())
                 .extracting(Bungae::getStatus)
-                .containsExactlyInAnyOrder(
+                .contains(
                         BungaeStatus.DATE_VOTING,
                         BungaeStatus.RECRUITING,
                         BungaeStatus.RECRUITING_CLOSED,
@@ -212,7 +224,7 @@ class CustomBungaeRepositoryTest {
     @DisplayName("lastCursorId가 null일 경우 가장 최근 것부터 조회된다")
     void findAllByAttendeeMemberIdAndStatusIn_withNullCursor_shouldReturnFromLatest() {
         // given
-        CursorPageable cursorPageable = new CursorPageable(null, 3); // lastCursorId가 null
+        CursorPageable cursorPageable = new CursorPageable(null, 3);
 
         // when
         CursorPage<Bungae> result = bungaeRepository.findAllByAttendeeMemberIdAndStatusIn(
@@ -229,14 +241,20 @@ class CustomBungaeRepositoryTest {
                 .map(Bungae::getId)
                 .toList();
 
-        List<Long> sortedIds = savedBungaes.stream()
-                .map(Bungae::getId)
-                .sorted((a, b) -> Long.compare(b, a)) // 내림차순 정렬
+        //  member가 참여한 모든 번개 중 최신 3개를 가져와서 검증
+        List<Long> allMemberBungaeIds = new ArrayList<>();
+        allMemberBungaeIds.addAll(groupSavedBungaes.stream().map(Bungae::getId).toList());
+        //  otherGroup의 번개 중 member가 참여하고 있는 RECRUITING, CLOSED 번개 ID 추가
+        allMemberBungaeIds.addAll(otherGroupSavedBungaes.stream()
+                                                        .filter(bungae -> bungae.getStatus() == BungaeStatus.RECRUITING || bungae.getStatus() == BungaeStatus.CLOSED)
+                                                        .map(Bungae::getId).toList());
+
+        List<Long> sortedIds = allMemberBungaeIds.stream()
+                .sorted((a, b) -> Long.compare(b, a))
                 .limit(3)
                 .toList();
 
         assertThat(resultIds).isEqualTo(sortedIds);
-        // nextCursorId는 반환된 마지막 요소의 ID여야 함
         assertThat(result.getNextCursorId()).isEqualTo(result.getContent().get(2).getId());
     }
 
@@ -329,12 +347,11 @@ class CustomBungaeRepositoryTest {
                 .map(BungaeDto::id)
                 .toList();
 
-        List<Long> sortedIds = savedBungaes.stream()
-                .filter(bungae -> bungae.getGroup().getId().equals(group.getId()))
-                .map(Bungae::getId)
-                .sorted((a, b) -> Long.compare(b, a)) //  내림차순 정렬
-                .limit(3)
-                .toList();
+        List<Long> sortedIds = groupSavedBungaes.stream()
+                                                .map(Bungae::getId)
+                                                .sorted((a, b) -> Long.compare(b, a)) //  내림차순 정렬
+                                                .limit(3)
+                                                .toList();
 
         assertThat(resultIds).isEqualTo(sortedIds);
     }

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -4,6 +4,7 @@ import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeAttendee;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.fixture.BungaeFixture;
+import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.config.QueryDslConfig;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.fixture.GroupFixture;
@@ -16,6 +17,7 @@ import com.midasdev.mybg.member.fixture.MemberFixture;
 import com.midasdev.mybg.member.repository.MemberRepository;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
+import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,15 @@ import java.util.List;
 import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 공통 given
+ * - Member: member, otherMember
+ * - Group: group, otherGroup
+ * - GroupMember: groupMember, otherGroupMember
+ * - Bungae: savedBungaes (group에서 member가 참여자로 등록된, 각각의 상태를 가지는 번개들),
+ *           otherMemberSavedBungaes (otherGroup에서 otherMember가 참여자로 등록된, 각각의 상태를 가지는 번개들)
+ */
 
 @DataJpaTest
 @Import(QueryDslConfig.class)
@@ -47,53 +58,79 @@ class CustomBungaeRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    private Member member;
-    private Group group;
+    private Member member, otherMember;
+    private Group group, otherGroup;
     private GroupMember groupMember;
+    private GroupMember otherGroupMember;
     private List<Bungae> savedBungaes;
+    private List<Bungae> otherMemberSavedBungaes;
+
 
     @BeforeEach
     void setUp() {
         // 기본 엔티티 생성 및 저장
         member = memberRepository.save(MemberFixture.create());
+        otherMember = memberRepository.save(MemberFixture.createSecondMember());
         group = groupRepository.save(GroupFixture.create(member));
+        otherGroup = groupRepository.save(GroupFixture.create(otherMember, "다른 그룹", "other-group-invitation-code"));
         groupMember = groupMemberRepository.save(GroupMemberFixture.create(group, member));
+        otherGroupMember = groupMemberRepository.save(GroupMemberFixture.create(otherGroup, otherMember));
 
         // 각 BungaeStatus별로 Bungae 생성 및 저장
         savedBungaes = new ArrayList<>();
+        otherMemberSavedBungaes = new ArrayList<>();
 
         // DATE_VOTING 번개 생성
         Bungae dateVotingBungae = bungaeRepository.save(
                 BungaeFixture.createWithDateVoting(group, groupMember));
         savedBungaes.add(dateVotingBungae);
 
+        // DATE_VOTING 번개 생성 (다른 그룹 멤버)
+        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithDateVoting(otherGroup, otherGroupMember)));
+
+
         // RECRUITING 번개 생성
         Bungae recruitingBungae = bungaeRepository.save(
                 BungaeFixture.createWithRecruiting(group, groupMember));
         savedBungaes.add(recruitingBungae);
 
+        // RECRUITING 번개 생성 (다른 그룹 멤버)
+        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruiting(otherGroup, otherGroupMember)));
+
+
         // RECRUITING_CLOSED 번개 생성
         Bungae recruitingClosedBungae = bungaeRepository.save(
                 BungaeFixture.createWithRecruitingClosed(group, groupMember));
         savedBungaes.add(recruitingClosedBungae);
+        // RECRUITING_CLOSED 번개 생성 (다른 그룹 멤버)
+        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithRecruitingClosed(otherGroup, otherGroupMember)));
 
         // CLOSED 번개 생성
         Bungae closedBungae = bungaeRepository.save(
                 BungaeFixture.createWithClosed(group, groupMember));
         savedBungaes.add(closedBungae);
+        // CLOSED 번개 생성 (다른 그룹 멤버)
+        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithClosed(otherGroup, otherGroupMember)));
 
         // CANCELLED 번개 생성
         Bungae cancelledBungae = bungaeRepository.save(
                 BungaeFixture.createWithCancelled(group, groupMember));
         savedBungaes.add(cancelledBungae);
+        // CANCELLED 번개 생성 (다른 그룹 멤버)
+        otherMemberSavedBungaes.add(bungaeRepository.save(BungaeFixture.createWithCancelled(otherGroup, otherGroupMember)));
 
         // 각 번개에 대해 BungaeAttendee 생성 (member가 참여자로 등록)
-        for (Bungae bungae : savedBungaes) {
+        saveAttendee(savedBungaes, groupMember);
+        saveAttendee(otherMemberSavedBungaes, otherGroupMember);
+    }
+
+    private void saveAttendee(List<Bungae> bungaes, GroupMember groupMember) {
+        for (Bungae bungae : bungaes) {
             BungaeAttendee attendee = BungaeAttendee.builder()
-                    .bungae(bungae)
-                    .groupMember(groupMember)
-                    .deleted(false)
-                    .build();
+                                                    .bungae(bungae)
+                                                    .groupMember(groupMember)
+                                                    .deleted(false)
+                                                    .build();
             bungaeAttendeeRepository.save(attendee);
         }
     }
@@ -139,9 +176,7 @@ class CustomBungaeRepositoryTest {
         );
 
         // then
-        assertThat(result.getContent())
-                .extracting(Bungae::getStatus)
-                .containsExactlyInAnyOrder(BungaeStatus.DATE_VOTING, BungaeStatus.RECRUITING);
+        assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent())
                 .extracting(Bungae::getStatus)
                 .doesNotContain(BungaeStatus.RECRUITING_CLOSED, BungaeStatus.CLOSED, BungaeStatus.CANCELLED);
@@ -203,5 +238,104 @@ class CustomBungaeRepositoryTest {
         assertThat(resultIds).isEqualTo(sortedIds);
         // nextCursorId는 반환된 마지막 요소의 ID여야 함
         assertThat(result.getNextCursorId()).isEqualTo(result.getContent().get(2).getId());
+    }
+
+    @Test
+    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조회 - lastCursorId, size")
+    void findByGroupIdAndStatusIn_withCursorAndSize_shouldReturnCorrectBungaes() {
+        // given
+        Long lastCursorId = Long.MAX_VALUE;
+        int pageSize = 2;
+        CursorPageable cursorPageable = new CursorPageable(lastCursorId, pageSize);
+        List<BungaeStatus> statuses = List.of(BungaeStatus.RECRUITING, BungaeStatus.DATE_VOTING);
+
+        // when
+        CursorPage<BungaeDto> result = bungaeRepository.findByGroupIdAndStatusIn(
+                group.getId(),
+                statuses,
+                cursorPageable
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(pageSize);
+        assertThat(result.getContent())
+                .extracting(BungaeDto::id)
+                .allMatch(id -> id < lastCursorId);
+        assertThat(result.getContent())
+                .extracting(BungaeDto::groupId)
+                .containsOnly(group.getId());
+    }
+
+    @Test
+    @DisplayName("B-3-R-2: 조건에 맞는 올바른 그룹 번개 조회 - status")
+    void findByGroupIdAndStatusIn_withStatus_shouldReturnFilteredBungaes() {
+        // given
+        List<BungaeStatus> targetStatuses = List.of(BungaeStatus.RECRUITING, BungaeStatus.CLOSED);
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // when
+        CursorPage<BungaeDto> result = bungaeRepository.findByGroupIdAndStatusIn(
+                group.getId(),
+                targetStatuses,
+                cursorPageable
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(BungaeDto::status)
+                .doesNotContain(BungaeStatus.DATE_VOTING, BungaeStatus.RECRUITING_CLOSED, BungaeStatus.CANCELLED);
+        assertThat(result.getContent())
+                .extracting(BungaeDto::groupId)
+                .containsOnly(group.getId());
+    }
+
+    @Test
+    @DisplayName("B-3-R-3: 조건에 맞는 올바른 그룹 번개 조회 - status가 null일 경우")
+    void findByGroupIdAndStatusIn_withNullStatus_shouldReturnAllBungaes() {
+        // given
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // when
+        CursorPage<BungaeDto> result = bungaeRepository.findByGroupIdAndStatusIn(
+                group.getId(),
+                null,
+                cursorPageable
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(5);
+        assertThat(result.getContent())
+                .extracting(BungaeDto::groupId)
+                .containsOnly(group.getId());
+    }
+
+    @Test
+    @DisplayName("B-3-R-4: lastCursorId가 null일 경우 가장 최근 것부터 그룹 번개 조회")
+    void findByGroupIdAndStatusIn_withNullCursor_shouldReturnFromLatest() {
+        // given
+        CursorPageable cursorPageable = new CursorPageable(null, 3); // [copilot] lastCursorId가 null
+
+        // when
+        CursorPage<BungaeDto> result = bungaeRepository.findByGroupIdAndStatusIn(
+                group.getId(),
+                null,
+                cursorPageable
+        );
+
+        // then
+        // ID 기준 내림차순 정렬 확인 (최신순)
+        List<Long> resultIds = result.getContent().stream()
+                .map(BungaeDto::id)
+                .toList();
+
+        List<Long> sortedIds = savedBungaes.stream()
+                .filter(bungae -> bungae.getGroup().getId().equals(group.getId()))
+                .map(Bungae::getId)
+                .sorted((a, b) -> Long.compare(b, a)) //  내림차순 정렬
+                .limit(3)
+                .toList();
+
+        assertThat(resultIds).isEqualTo(sortedIds);
     }
 }

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -246,7 +246,7 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조�� - lastCursorId, size")
+    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조회 - lastCursorId, size")
     void findByGroupIdAndStatusIn_withCursorAndSize_shouldReturnCorrectBungaes() {
         // given
         Long lastCursorId = Long.MAX_VALUE;

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -1,11 +1,15 @@
 package com.midasdev.mybg.bungae.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeAttendee;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.fixture.BungaeFixture;
 import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.config.QueryDslConfig;
+import com.midasdev.mybg.global.util.cursor_page.CursorPage;
+import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
 import com.midasdev.mybg.group.domain.Group;
 import com.midasdev.mybg.group.fixture.GroupFixture;
 import com.midasdev.mybg.group.repository.GroupRepository;
@@ -15,30 +19,24 @@ import com.midasdev.mybg.group_member.repository.GroupMemberRepository;
 import com.midasdev.mybg.member.domain.Member;
 import com.midasdev.mybg.member.fixture.MemberFixture;
 import com.midasdev.mybg.member.repository.MemberRepository;
-import com.midasdev.mybg.global.util.cursor_page.CursorPage;
-import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.springframework.context.annotation.Import;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * 공통 given
  * - Member: member, otherMember
  * - Group: group, otherGroup
  * - GroupMember:
- *     - group : groupMember (member가 group에 참여자로 등록된 상태)
- *     - otherGroup : otherGroupMember(otherMember), memberInOtherGroup(member)
- * - Bungae: savedBungaes (group에서 member가 참여자로 등록된, 각각의 상태를 가지는 번개들),
- *           otherMemberSavedBungaes (otherGroup에서 otherMember가 참여자로 등록된, 각각의 상태를 가지는 번개들)
- *           + member가 otherGroup의 RECRUITING, CLOSED 번개에도 참여
+ *     * group : groupMember (member가 group에 참여자로 등록된 상태)
+ *     * otherGroup : otherGroupMember(otherMember), memberInOtherGroup(member)
+ * - Bungae: savedBungaes (group에서 member가 참여자로 등록된, 각각의 상태를 가지는 번개들), otherMemberSavedBungaes (otherGroup에서 otherMember가 참여자로 등록된, 각각의 상태를 가지는 번개들)
+ * + member가 otherGroup의 RECRUITING, CLOSED 번개에도 참여
  */
 
 @DataJpaTest
@@ -238,21 +236,22 @@ class CustomBungaeRepositoryTest {
 
         // ID 기준 내림차순 정렬 확인 (최신순)
         List<Long> resultIds = result.getContent().stream()
-                .map(Bungae::getId)
-                .toList();
+                                     .map(Bungae::getId)
+                                     .toList();
 
         //  member가 참여한 모든 번개 중 최신 3개를 가져와서 검증
         List<Long> allMemberBungaeIds = new ArrayList<>();
         allMemberBungaeIds.addAll(groupSavedBungaes.stream().map(Bungae::getId).toList());
         //  otherGroup의 번개 중 member가 참여하고 있는 RECRUITING, CLOSED 번개 ID 추가
         allMemberBungaeIds.addAll(otherGroupSavedBungaes.stream()
-                                                        .filter(bungae -> bungae.getStatus() == BungaeStatus.RECRUITING || bungae.getStatus() == BungaeStatus.CLOSED)
+                                                        .filter(bungae -> bungae.getStatus() == BungaeStatus.RECRUITING
+                                                                || bungae.getStatus() == BungaeStatus.CLOSED)
                                                         .map(Bungae::getId).toList());
 
         List<Long> sortedIds = allMemberBungaeIds.stream()
-                .sorted((a, b) -> Long.compare(b, a))
-                .limit(3)
-                .toList();
+                                                 .sorted((a, b) -> Long.compare(b, a))
+                                                 .limit(3)
+                                                 .toList();
 
         assertThat(resultIds).isEqualTo(sortedIds);
         assertThat(result.getNextCursorId()).isEqualTo(result.getContent().get(2).getId());
@@ -332,7 +331,7 @@ class CustomBungaeRepositoryTest {
     @DisplayName("B-3-R-4: lastCursorId가 null일 경우 가장 최근 것부터 그룹 번개 조회")
     void findByGroupIdAndStatusIn_withNullCursor_shouldReturnFromLatest() {
         // given
-        CursorPageable cursorPageable = new CursorPageable(null, 3); // [copilot] lastCursorId가 null
+        CursorPageable cursorPageable = new CursorPageable(null, 3);
 
         // when
         CursorPage<BungaeDto> result = bungaeRepository.findByGroupIdAndStatusIn(
@@ -344,8 +343,8 @@ class CustomBungaeRepositoryTest {
         // then
         // ID 기준 내림차순 정렬 확인 (최신순)
         List<Long> resultIds = result.getContent().stream()
-                .map(BungaeDto::id)
-                .toList();
+                                     .map(BungaeDto::id)
+                                     .toList();
 
         List<Long> sortedIds = groupSavedBungaes.stream()
                                                 .map(Bungae::getId)
@@ -355,4 +354,5 @@ class CustomBungaeRepositoryTest {
 
         assertThat(resultIds).isEqualTo(sortedIds);
     }
+
 }

--- a/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceUnitTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceUnitTest.java
@@ -1,0 +1,93 @@
+package com.midasdev.mybg.bungae.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.midasdev.mybg.bungae.domain.BungaeStatus;
+import com.midasdev.mybg.bungae.repository.BungaeAttendeeRepository;
+import com.midasdev.mybg.bungae.repository.BungaeRecruitDateOptionRepository;
+import com.midasdev.mybg.bungae.repository.BungaeRepository;
+import com.midasdev.mybg.fixture.CursorPageableFixture;
+import com.midasdev.mybg.global.exception.ApplicationException;
+import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
+import com.midasdev.mybg.group.domain.Group;
+import com.midasdev.mybg.group.fixture.GroupFixture;
+import com.midasdev.mybg.group.repository.GroupRepository;
+import com.midasdev.mybg.group_member.repository.GroupMemberRepository;
+import com.midasdev.mybg.member.domain.Member;
+import com.midasdev.mybg.member.fixture.MemberFixture;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+public class BungaeServiceUnitTest {
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
+    private BungaeRepository bungaeRepository;
+
+    @Mock
+    private BungaeRecruitDateOptionRepository bungaeRecruitDateOptionRepository;
+
+    @Mock
+    private BungaeAttendeeRepository bungaeAttendeeRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @InjectMocks
+    private BungaeService bungaeService;
+
+    @Test
+    @DisplayName("그룹이 존재하지 않을 때 예외 발생")
+    void findBungaesByGroupIdAndStatuses_ShouldThrowException_WhenGroupNotFound() {
+        // given
+        Member member = MemberFixture.create();
+        List<BungaeStatus> statuses = List.of(BungaeStatus.DATE_VOTING);
+        CursorPageable cursorPageable = CursorPageableFixture.create();
+
+        // when - 그룹이 존재하지 않도록 Mock 설정
+        when(groupRepository.findByIdAndDeletedIsFalse(any(Long.class)))
+                .thenReturn(Optional.empty());
+
+        // then - 예외 발생 검증
+        assertThatThrownBy(() -> bungaeService.findBungaesByGroupIdAndStatuses(
+                member, 1L, statuses, cursorPageable))
+                .isInstanceOf(ApplicationException.class);
+    }
+
+    @Test
+    @DisplayName("그룹이 존재하고 멤버가 그룹에 속하지 않을 때 예외 발생")
+    void findBungaesByGroupIdAndStatuses_ShouldThrowException_WhenMemberNotInGroup() {
+        // given
+        Member member = MemberFixture.create();
+        Member groupOwner = MemberFixture.create();
+        Group group = GroupFixture.create(groupOwner);
+        List<BungaeStatus> statuses = List.of(BungaeStatus.DATE_VOTING);
+        CursorPageable cursorPageable = CursorPageableFixture.create();
+
+        // when - 그룹은 존재하지만 멤버가 그룹에 속하지 않도록 Mock 설정
+        when(groupRepository.findByIdAndDeletedIsFalse(any(Long.class)))
+                .thenReturn(Optional.of(group));
+        when(groupMemberRepository.findByMemberAndGroup(member, group))
+                .thenReturn(Optional.empty());
+
+        // then - 예외 발생 검증
+        assertThatThrownBy(() -> bungaeService.findBungaesByGroupIdAndStatuses(
+                member, 1L, statuses, cursorPageable))
+                .isInstanceOf(ApplicationException.class);
+    }
+}

--- a/src/test/java/com/midasdev/mybg/fixture/CursorPageableFixture.java
+++ b/src/test/java/com/midasdev/mybg/fixture/CursorPageableFixture.java
@@ -1,0 +1,15 @@
+package com.midasdev.mybg.fixture;
+
+import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
+import com.midasdev.mybg.global.util.cursor_page.SortOrder;
+
+public class CursorPageableFixture {
+    public static CursorPageable create() {
+        return CursorPageable.builder()
+                .lastCursorId(0L)
+                .pageSize(10)
+                .sortOrder(SortOrder.ASC)
+                .build();
+    }
+
+}

--- a/src/test/java/com/midasdev/mybg/global/util/cursor_page/CursorPageTest.java
+++ b/src/test/java/com/midasdev/mybg/global/util/cursor_page/CursorPageTest.java
@@ -1,0 +1,160 @@
+package com.midasdev.mybg.global.util.cursor_page;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CursorPageTest {
+
+    @Test
+    @DisplayName("fetchedContent가 pageSize보다 적을 때 올바른 CursorPage 생성")
+    void constructor_ShouldReturnFalseHasNext_WhenFetchedContentSizeLessThanPageSize() {
+        // given
+        int pageSize = 5;
+        List<TestLongIdentifiable> fetchedContent = createTestData(3);
+
+        // when
+        CursorPage<TestLongIdentifiable> cursorPage = new CursorPage<>(fetchedContent, pageSize);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(cursorPage.isHasNext()).isFalse();
+            softly.assertThat(cursorPage.getContent()).hasSize(3);
+            softly.assertThat(cursorPage.getNextCursorId()).isNull();
+            softly.assertThat(cursorPage.getPageSize()).isEqualTo(pageSize);
+        });
+    }
+
+    @Test
+    @DisplayName("fetchedContent가 pageSize와 같을 때 올바른 CursorPage 생성")
+    void constructor_ShouldReturnFalseHasNext_WhenFetchedContentSizeEqualsPageSize() {
+        // given
+        int pageSize = 5;
+        List<TestLongIdentifiable> fetchedContent = createTestData(5);
+
+        // when
+        CursorPage<TestLongIdentifiable> cursorPage = new CursorPage<>(fetchedContent, pageSize);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(cursorPage.isHasNext()).isFalse();
+            softly.assertThat(cursorPage.getContent()).hasSize(5);
+            softly.assertThat(cursorPage.getNextCursorId()).isNull();
+            softly.assertThat(cursorPage.getPageSize()).isEqualTo(pageSize);
+        });
+    }
+
+    @Test
+    @DisplayName("fetchedContent가 pageSize+1일 때 올바른 CursorPage 생성")
+    void constructor_ShouldReturnTrueHasNext_WhenFetchedContentSizeEqualsPageSizePlusOne() {
+        // given
+        int pageSize = 5;
+        List<TestLongIdentifiable> fetchedContent = createTestData(6);
+
+        // when
+        CursorPage<TestLongIdentifiable> cursorPage = new CursorPage<>(fetchedContent, pageSize);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(cursorPage.isHasNext()).isTrue();
+            softly.assertThat(cursorPage.getContent()).hasSize(5);
+            softly.assertThat(cursorPage.getNextCursorId()).isEqualTo(5L);
+            softly.assertThat(cursorPage.getPageSize()).isEqualTo(pageSize);
+        });
+    }
+
+    @Test
+    @DisplayName("fetchedContent가 pageSize+2 이상일 때 예외 발생")
+    void constructor_ShouldThrowException_WhenFetchedContentSizeGreaterThanPageSizePlusOne() {
+        // given
+        int pageSize = 5;
+        List<TestLongIdentifiable> fetchedContent = createTestData(8);
+
+        // when & then
+        assertThatThrownBy(() -> new CursorPage<>(fetchedContent, pageSize))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("map 메서드로 타입 변환 시 올바른 CursorPage 생성")
+    void map_ShouldReturnCorrectCursorPage_WhenTypeTransformation() {
+        // given
+        int pageSize = 3;
+        List<TestLongIdentifiable> fetchedContent = createTestData(4);
+        CursorPage<TestLongIdentifiable> originalPage = new CursorPage<>(fetchedContent, pageSize);
+
+        // when
+        CursorPage<MappedTestLongIdentifiable> mappedPage = originalPage.map(item ->
+            new MappedTestLongIdentifiable(item.getId(), "mapped_" + item.getId()));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(mappedPage.getContent()).hasSize(3);
+            softly.assertThat(mappedPage.isHasNext()).isTrue();
+            softly.assertThat(mappedPage.getNextCursorId()).isEqualTo(3L);
+            softly.assertThat(mappedPage.getPageSize()).isEqualTo(pageSize);
+        });
+    }
+
+    @Test
+    @DisplayName("빈 리스트로 CursorPage 생성 시 올바른 초기화")
+    void constructor_ShouldReturnCorrectCursorPage_WhenEmptyList() {
+        // given
+        int pageSize = 5;
+        List<TestLongIdentifiable> fetchedContent = List.of();
+
+        // when
+        CursorPage<TestLongIdentifiable> cursorPage = new CursorPage<>(fetchedContent, pageSize);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(cursorPage.isHasNext()).isFalse();
+            softly.assertThat(cursorPage.getContent()).isEmpty();
+            softly.assertThat(cursorPage.getNextCursorId()).isNull();
+            softly.assertThat(cursorPage.getPageSize()).isEqualTo(pageSize);
+        });
+    }
+
+    private static class TestLongIdentifiable implements LongIdentifiable {
+        private final Long id;
+
+        public TestLongIdentifiable(Long id) {
+            this.id = id;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+    }
+
+    // map 테스트를 위한 추가 테스트용 클래스
+    private static class MappedTestLongIdentifiable implements LongIdentifiable {
+        private final Long id;
+        private final String name;
+
+        public MappedTestLongIdentifiable(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    private List<TestLongIdentifiable> createTestData(int size) {
+        return IntStream.rangeClosed(1, size)
+                        .mapToObj(i -> new TestLongIdentifiable((long) i))
+                        .toList();
+    }
+}

--- a/src/test/java/com/midasdev/mybg/group/fixture/GroupFixture.java
+++ b/src/test/java/com/midasdev/mybg/group/fixture/GroupFixture.java
@@ -14,4 +14,15 @@ public class GroupFixture {
                 .deleted(false)
                 .build();
     }
+
+    public static Group create(Member owner, String name, String invitationCode) {
+        return Group.builder()
+                    .name(name)
+                    .profileImageUrl("http://test.com/group.png")
+                    .invitationCode(invitationCode)
+                    .maxMemberCount(100)
+                    .owner(owner)
+                    .deleted(false)
+                    .build();
+    }
 }

--- a/src/test/java/com/midasdev/mybg/member/fixture/MemberFixture.java
+++ b/src/test/java/com/midasdev/mybg/member/fixture/MemberFixture.java
@@ -13,4 +13,13 @@ public class MemberFixture {
                 .oauthAccount(new OauthAccount(OauthProvider.KAKAO, "test-oauth-sub"))
                 .build();
     }
+
+    public static Member createSecondMember() {
+        return Member.builder()
+                     .name("테스트멤버2")
+                     .profileImageUrl("http://test.com/profile.png")
+                     .deleted(false)
+                     .oauthAccount(new OauthAccount(OauthProvider.KAKAO, "test-oauth-sub2"))
+                     .build();
+    }
 }


### PR DESCRIPTION
# 🔍 Summary
그룹 별 번개를 조회할 수 있는 API 구현

# 📑 Description
- 커서 페이징과 복수 상태 조건으로 그룹 별 번개를 조회할 수 있는 API를 구현합니다.
- 관련 테스트 코드를 작성합니다.
- 커서 페이징 관련 로직을 분리하고 테스트 코드를 작성합니다.

# 🔗 Related Issues
- #32 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정