### PR TITLE
번개 생성 시 번개 상태에 따른 로직 분리

### DIFF
--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/BungaeCreateRequest.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/request/BungaeCreateRequest.java
@@ -14,12 +14,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
 @Schema(description = "번개 생성 요청")
+@Builder
 @VoteRequiredIfHasMultipleDateCandidates
 public record BungaeCreateRequest(
 

--- a/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
+++ b/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
@@ -124,7 +124,7 @@ public class BungaeService {
             bungaeAttendeeRepository.save(attendee);
         }
 
-        // TODO: 7. 알림 전송 (번개 생성 알림)
+        // TODO: 알림 전송 (번개 생성 알림)
 
         // 필요하다면 반환
         return savedBungae;

--- a/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
+++ b/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
@@ -92,30 +92,37 @@ public class BungaeService {
         // 4. Bungae 엔티티 저장
         Bungae savedBungae = bungaeRepository.save(bungae);
 
-        // 5. 날짜 후보가 여러개라면 날짜 후보 저장 (BungaeRecruitDateOption)
         if (!request.hasSingleDateCandidate()) {
+            // 5. 날짜 후보가 여러개라면 날짜 후보 저장 (BungaeRecruitDateOption)
+            List<BungaeRecruitDateOption> savedDateOptions = new ArrayList<>();
             request.dateCandidates().forEach(date -> {
                 BungaeRecruitDateOption option = BungaeRecruitDateOption.builder()
                                                                         .dateOption(date)
                                                                         .bungae(savedBungae)
                                                                         .build();
-                bungaeRecruitDateOptionRepository.save(option);
+                savedDateOptions.add(bungaeRecruitDateOptionRepository.save(option));
             });
+
+            // 6. DATE_VOTING인 경우, 날짜 후보에 대해 번개 생성자의 투표를 저장
+            List<BungaeDateVote> hostVotes = savedDateOptions.stream()
+                    .map(dateOption -> BungaeDateVote.builder()
+                            .voter(hostGroupMember)
+                            .dateOption(dateOption)
+                            .build())
+                    .toList();
+            bungaeDateVoteRepository.saveAll(hostVotes);
+
+            eventPublisher.publishEvent(new BungaeVoteCreatedEvent(savedBungae.getId()));
+            // TODO: 투표 생성 이벤트 처리 (필요한가? - 처리할 리스트 정리부터)
+        } else {
+            // 7. RECRUITING인 경우, Bungae 참여자에 host GroupMember 추가
+            BungaeAttendee attendee = BungaeAttendee.builder()
+                                                    .bungae(savedBungae)
+                                                    .groupMember(hostGroupMember)
+                                                    .deleted(false)
+                                                    .build();
+            bungaeAttendeeRepository.save(attendee);
         }
-
-        // TODO: 날짜 후보에 대해 번개 생성자의 투표를 저장
-
-        // TODO: 삭제
-        // 6. Bungae 참여자에 host GroupMember 추가
-        BungaeAttendee attendee = BungaeAttendee.builder()
-                                                .bungae(savedBungae)
-                                                .groupMember(hostGroupMember)
-                                                .deleted(false)
-                                                .build();
-        bungaeAttendeeRepository.save(attendee);
-
-        eventPublisher.publishEvent(new BungaeVoteCreatedEvent(savedBungae.getId()));
-        // TODO: 투표 생성 이벤트 처리 (필요한가? - 처리할 리스트 정리부터)
 
         // TODO: 7. 알림 전송 (번개 생성 알림)
 

--- a/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
+++ b/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
@@ -103,7 +103,7 @@ public class BungaeService {
                 savedDateOptions.add(bungaeRecruitDateOptionRepository.save(option));
             });
 
-            // 6. DATE_VOTING인 경우, 날짜 후보에 대해 번개 생성자의 투표를 저장
+            // 6. 날짜 투표가 필요한 경우, 날짜 후보에 대해 번개 생성자의 투표를 저장
             List<BungaeDateVote> hostVotes = savedDateOptions.stream()
                     .map(dateOption -> BungaeDateVote.builder()
                             .voter(hostGroupMember)
@@ -115,7 +115,7 @@ public class BungaeService {
             eventPublisher.publishEvent(new BungaeVoteCreatedEvent(savedBungae.getId()));
             // TODO: 투표 생성 이벤트 처리 (필요한가? - 처리할 리스트 정리부터)
         } else {
-            // 7. RECRUITING인 경우, Bungae 참여자에 host GroupMember 추가
+            // 7. 날짜가 확정된 경우, Bungae 참여자에 host GroupMember 추가
             BungaeAttendee attendee = BungaeAttendee.builder()
                                                     .bungae(savedBungae)
                                                     .groupMember(hostGroupMember)

--- a/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceEventTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceEventTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.midasdev.mybg.bungae.controller.dto.request.BungaeCreateRequest;
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.repository.BungaeAttendeeRepository;
+import com.midasdev.mybg.bungae.repository.BungaeDateVoteRepository;
 import com.midasdev.mybg.bungae.repository.BungaeRecruitDateOptionRepository;
 import com.midasdev.mybg.bungae.repository.BungaeRepository;
 import com.midasdev.mybg.bungae.service.event.BungaeVoteCreatedEvent;
@@ -42,6 +43,8 @@ class BungaeServiceEventTest {
     @Mock
     private BungaeAttendeeRepository bungaeAttendeeRepository;
     @Mock
+    private BungaeDateVoteRepository bungaeDateVoteRepository;
+    @Mock
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private GroupFinder groupFinder;
@@ -66,8 +69,8 @@ class BungaeServiceEventTest {
     }
 
     @Test
-    @DisplayName("날짜 후보가 1개일 때 번개 생성 시 BungaeVoteCreatedEvent가 발행된다")
-    void createBungae_withSingleDateCandidate_shouldPublishEvent() {
+    @DisplayName("B-1-SU-1: 날짜 후보가 1개일 때 번개 생성 시 BungaeVoteCreatedEvent가 발행되지 않는다.")
+    void B_1_SU_1() {
         // given
         BungaeCreateRequest request = new BungaeCreateRequest(
                 "이벤트 테스트 번개1",
@@ -86,13 +89,13 @@ class BungaeServiceEventTest {
         bungaeService.createBungae(member, request);
 
         // then
-        verify(eventPublisher, times(1))
+        verify(eventPublisher, times(0))
                 .publishEvent(any(BungaeVoteCreatedEvent.class));
     }
 
     @Test
-    @DisplayName("날짜 후보가 2개 이상일 때 번개 생성 시 BungaeVoteCreatedEvent가 발행된다")
-    void createBungae_withMultipleDateCandidates_shouldPublishEvent() {
+    @DisplayName("B-1-SU-2: 날짜 후보가 2개 이상일 때 번개 생성 시 BungaeVoteCreatedEvent가 발행된다")
+    void B_1_SU_2() {
         // given
         List<LocalDate> dateCandidates = List.of(
                 LocalDate.now().plusDays(1),

--- a/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/service/BungaeServiceTest.java
@@ -87,18 +87,19 @@ class BungaeServiceTest extends DatabaseTestSupport {
     @DisplayName("B-1-S-1: 날짜 후보가 1개일 때 Bungae 생성")
     void B_1_S_1() {
         // given
-        BungaeCreateRequest request = new BungaeCreateRequest(
-                "테스트 번개",
-                "설명",
-                2,
-                10,
-                false,
-                "서울",
-                LocalTime.of(18, 0),
-                List.of(LocalDate.now().plusDays(1)),
-                null,
-                group.getId()
-        );
+        BungaeCreateRequest request = BungaeCreateRequest.builder()
+                .name("테스트 번개")
+                .description("설명")
+                .minAttendees(2)
+                .maxAttendees(10)
+                .isOnline(false)
+                .location("서울")
+                .bungaeTime(LocalTime.of(18, 0))
+                .dateCandidates(List.of(LocalDate.now().plusDays(1)))
+                .dateVoteClosedAt(null)
+                .groupId(group.getId())
+                .build();
+        
 
         // when
         Bungae bungae = bungaeService.createBungae(member, request);
@@ -122,18 +123,18 @@ class BungaeServiceTest extends DatabaseTestSupport {
         LocalTime bungaeTime = LocalTime.of(19, 0);
         LocalDateTime voteClosedAt = LocalDateTime.now().plusDays(1);
 
-        BungaeCreateRequest request = new BungaeCreateRequest(
-                "테스트 번개2",
-                "설명2",
-                2,
-                10,
-                false,
-                "서울",
-                bungaeTime,
-                dateCandidates,
-                voteClosedAt,
-                group.getId()
-        );
+        BungaeCreateRequest request = BungaeCreateRequest.builder()
+                .name("테스트 번개2")
+                .description("설명2")
+                .minAttendees(2)
+                .maxAttendees(10)
+                .isOnline(false)
+                .location("서울")
+                .bungaeTime(bungaeTime)
+                .dateCandidates(dateCandidates)
+                .dateVoteClosedAt(voteClosedAt)
+                .groupId(group.getId())
+                .build();
 
         // when
         Bungae bungae = bungaeService.createBungae(member, request);
@@ -157,18 +158,18 @@ class BungaeServiceTest extends DatabaseTestSupport {
         LocalTime bungaeTime = LocalTime.of(19, 0);
         LocalDateTime voteClosedAt = LocalDateTime.now().plusDays(1);
 
-        BungaeCreateRequest request = new BungaeCreateRequest(
-                "테스트 번개2",
-                "설명2",
-                2,
-                10,
-                false,
-                "서울",
-                bungaeTime,
-                dateCandidates,
-                voteClosedAt,
-                group.getId()
-        );
+        BungaeCreateRequest request = BungaeCreateRequest.builder()
+                .name("테스트 번개2")
+                .description("설명2")
+                .minAttendees(2)
+                .maxAttendees(10)
+                .isOnline(false)
+                .location("서울")
+                .bungaeTime(bungaeTime)
+                .dateCandidates(dateCandidates)
+                .dateVoteClosedAt(voteClosedAt)
+                .groupId(group.getId())
+                .build();
 
         // when
         bungaeService.createBungae(member, request);
@@ -179,6 +180,82 @@ class BungaeServiceTest extends DatabaseTestSupport {
         assertThat(options)
                 .extracting(BungaeRecruitDateOption::getDateOption)
                 .containsExactlyInAnyOrderElementsOf(dateCandidates);
+    }
+
+    @Test
+    @DisplayName("B-1-S-4: 생성된 번개가 날짜 투표를 필요로 할 경우, 각 날짜 후보마다 번개 주최자의 투표가 저장")
+    void B_1_S_4() {
+        // given
+        List<LocalDate> dateCandidates = List.of(
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(2),
+                LocalDate.now().plusDays(3)
+        );
+        LocalTime bungaeTime = LocalTime.of(19, 0);
+        LocalDateTime voteClosedAt = LocalDateTime.now().plusDays(1);
+
+        BungaeCreateRequest request = BungaeCreateRequest.builder()
+                .name("테스트 번개")
+                .description("설명")
+                .minAttendees(2)
+                .maxAttendees(10)
+                .isOnline(false)
+                .location("서울")
+                .bungaeTime(bungaeTime)
+                .dateCandidates(dateCandidates)
+                .dateVoteClosedAt(voteClosedAt)
+                .groupId(group.getId())
+                .build();
+
+        // when
+        Bungae bungae = bungaeService.createBungae(member, request);
+
+        // then
+        List<BungaeDateVote> hostVotes = bungaeDateVoteTestRepository.findByBungaeIdAndVoterId(
+                bungae.getId(),
+                hostGroupMember.getId()
+        );
+
+        List<LocalDate> votedDates = hostVotes.stream()
+                .map(vote -> vote.getDateOption().getDateOption())
+                .toList();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(hostVotes).hasSize(dateCandidates.size());
+            softly.assertThat(votedDates).containsExactlyInAnyOrderElementsOf(dateCandidates);
+            softly.assertThat(hostVotes).allMatch(vote -> vote.getVoter().getId().equals(hostGroupMember.getId()));
+        });
+    }
+
+    @Test
+    @DisplayName("B-1-S-5: 생성된 번개가 날짜 투표를 필요로 하지 않을 경우, 번개 주최자가 자동으로 참가자로 저장")
+    void B_1_S_5() {
+        // given
+        BungaeCreateRequest request = BungaeCreateRequest.builder()
+                .name("테스트 번개")
+                .description("설명")
+                .minAttendees(2)
+                .maxAttendees(10)
+                .isOnline(false)
+                .location("서울")
+                .bungaeTime(LocalTime.of(18, 0))
+                .dateCandidates(List.of(LocalDate.now().plusDays(1)))
+                .dateVoteClosedAt(null)
+                .groupId(group.getId())
+                .build();
+
+        // when
+        Bungae bungae = bungaeService.createBungae(member, request);
+
+        // then
+        List<BungaeAttendee> attendees = bungaeAttendeeRepository.findByBungaeIdAndDeletedFalse(bungae.getId());
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(attendees).hasSize(1);
+            softly.assertThat(attendees.get(0).getGroupMember().getId()).isEqualTo(hostGroupMember.getId());
+            softly.assertThat(attendees.get(0).getBungae().getId()).isEqualTo(bungae.getId());
+            softly.assertThat(attendees.get(0).getDeleted()).isFalse();
+        });
     }
 
     @Test


### PR DESCRIPTION
# 🔍 Summary
- 날짜 투표가 필요한 경우, 날짜 후보에 대해 번개 생성자의 투표를 저장
- 날짜가 확정된 경우, Bungae 참여자에 host GroupMember 추가
- 관련 테스트 추가

# 📑 Description

# 🔗 Related Issues
- #56 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정