### PR TITLE
[#65][BUNGAE-005,010] 그룹별 번개 조회, 번개 참여에 참여 및 신청 여부 포함

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // h2 database
-    implementation 'com.h2database:h2'
+    // implementation 'com.h2database:h2'
 
     // actuator
     implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/src/main/java/com/midasdev/mybg/auth/AuthController.java
+++ b/src/main/java/com/midasdev/mybg/auth/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
     private final JwtClaimResolver jwtClaimResolver;
 
     @Operation(
-            summary = "로그인 API",
+            summary = "[AUTH-001] 로그인 API",
             description = "Social 인증 후 서버에서 발급한 authToken을 통해 accessToken, refreshToken을 발급합니다.")
     @PostMapping
     public ResponseEntity<AuthResponse> generateToken(@RequestBody @Valid AuthRequest authRequest) {
@@ -60,7 +60,7 @@ public class AuthController {
     }
 
     @Operation(
-            summary = "access token 재발급 API",
+            summary = "[AUTH-003] access token 재발급 API",
             description = "refresh token을 통해 새로운 accessToken, refreshToken을 발급합니다.")
     @PostMapping("/reissue")
     public ResponseEntity<TokenReIssueResponse> reIssueToken(
@@ -87,7 +87,7 @@ public class AuthController {
 
     // Refactor: SecurityRequirement name 상수 관리에 대해 생각
     @Operation(
-            summary = "로그아웃 API",
+            summary = "[AUTH-002] 로그아웃 API",
             description = "사용자의 refresh token을 삭제하여 로그아웃합니다.",
             security = @SecurityRequirement(name = "BearerAuth"))
     @PostMapping("/logout")

--- a/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/BungaeController.java
@@ -43,7 +43,7 @@ public class BungaeController {
     private final BungaeService bungaeService;
 
     @Operation(
-            summary = "번개 생성 API",
+            summary = "[BUNGAE-001] 번개 생성 API",
             description =
                     """
                     번개를 생성합니다.
@@ -63,7 +63,7 @@ public class BungaeController {
     }
 
     @Operation(
-            summary = "내 번개모임 목록 조회 API",
+            summary = "[BUNGAE-002] 내 번개모임 목록 조회 API",
             description =
                     """
                     로그인한 사용자가 참여한 번개모임 목록을 조회합니다.
@@ -85,7 +85,7 @@ public class BungaeController {
     }
 
     @Operation(
-            summary = "그룹별 번개모임 목록 조회 API",
+            summary = "[BUNGAE-005] 그룹별 번개모임 목록 조회 API",
             description =
                     """
                     특정 그룹의 번개모임 목록을 조회합니다.
@@ -109,7 +109,7 @@ public class BungaeController {
     }
 
     @Operation(
-            summary = "번개 투표 가능한 날짜들 조회 API",
+            summary = "[BUNGAE-003] 번개 투표 가능한 날짜들 조회 API",
             description =
                     """
                     번개의 투표 가능한 날짜들을 조회합니다.
@@ -125,7 +125,7 @@ public class BungaeController {
     }
 
     @Operation(
-            summary = "번개 날짜 투표 API",
+            summary = "[BUNGAE-009] 번개 날짜 투표 API",
             description =
                     """
                     번개 날짜에 투표합니다.
@@ -143,7 +143,7 @@ public class BungaeController {
     }
 
     @Operation(
-            summary = "번개 참여 API",
+            summary = "[BUNGAE-010] 번개 참여 API",
             description =
                     """
                     번개에 참여합니다.

--- a/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
+++ b/src/main/java/com/midasdev/mybg/bungae/controller/dto/response/BungaeResponse.java
@@ -25,7 +25,9 @@ public record BungaeResponse(
         BungaeStatus status,
         Long groupId,
         Long hostGroupMemberId,
-        LocalDateTime createdAt)
+        LocalDateTime createdAt,
+        Boolean hasJoined,
+        Boolean hasVoted)
         implements LongIdentifiable {
 
     public static BungaeResponse from(Bungae bungae) {
@@ -44,6 +46,8 @@ public record BungaeResponse(
                 .groupId(bungae.getGroup().getId())
                 .hostGroupMemberId(bungae.getHost().getId())
                 .createdAt(bungae.getCreatedAt())
+                .hasJoined(null)
+                .hasVoted(null)
                 .build();
     }
 
@@ -64,6 +68,8 @@ public record BungaeResponse(
                 .groupId(bungaeDto.groupId())
                 .hostGroupMemberId(bungaeDto.hostGroupMemberId())
                 .createdAt(bungaeDto.createdAt())
+                .hasJoined(bungaeDto.hasJoined())
+                .hasVoted(bungaeDto.hasVoted())
                 .build();
     }
 

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepository.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepository.java
@@ -13,7 +13,7 @@ public interface CustomBungaeRepository {
             Long memberId, List<BungaeStatus> statuses, CursorPageable cursorPageable);
 
     CursorPage<BungaeDto> findByGroupIdAndStatusIn(
-            Long groupId, List<BungaeStatus> statuses, CursorPageable pageable);
+            Long groupId, List<BungaeStatus> statuses, CursorPageable pageable, Long memberId);
 
-    Optional<BungaeDto> findBungaeDtoById(Long bungaeId);
+    Optional<BungaeDto> findBungaeDtoById(Long bungaeId, Long memberId);
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -7,6 +7,9 @@ import com.midasdev.mybg.bungae.domain.QBungaeDateVote;
 import com.midasdev.mybg.bungae.domain.QBungaeRecruitDateOption;
 import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.bungae.repository.dto.QBungaeDto;
+import com.midasdev.mybg.global.exception.ApplicationException;
+import com.midasdev.mybg.global.exception.ApplicationExceptionType;
+import com.midasdev.mybg.global.util.assertion.Assertion;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
 import com.midasdev.mybg.global.util.cursor_page.CursorPageable;
 import com.querydsl.core.types.Expression;
@@ -131,6 +134,13 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
     }
 
     private Expression<BungaeDto> createBungaeDtoProjection(Long memberId) {
+        Assertion.with(memberId)
+                .setValidation(id -> id != null)
+                .validateOrThrow(
+                        () ->
+                                new ApplicationException(ApplicationExceptionType.GLOBAL_INTERNAL_SERVER_ERROR,
+                                        "MemberId for BungaeDto projection cannot be null"));
+
         return new QBungaeDto(
                 bungae.id,
                 bungae.name,
@@ -159,10 +169,6 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
     }
 
     private Expression<Boolean> createHasJoinedSubQuery(Long memberId) {
-        if (memberId == null) {
-            return Expressions.nullExpression(Boolean.class);
-        }
-
         QBungaeAttendee subAttendee = new QBungaeAttendee("subAttendee");
         return JPAExpressions.selectOne()
                 .from(subAttendee)
@@ -174,10 +180,6 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
     }
 
     private Expression<Boolean> createHasVotedSubQuery(Long memberId) {
-        if (memberId == null) {
-            return Expressions.nullExpression(Boolean.class);
-        }
-
         QBungaeDateVote bungaeDateVote = QBungaeDateVote.bungaeDateVote;
         QBungaeRecruitDateOption dateOption = QBungaeRecruitDateOption.bungaeRecruitDateOption;
         return JPAExpressions.selectOne()

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -138,7 +138,8 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 .setValidation(id -> id != null)
                 .validateOrThrow(
                         () ->
-                                new ApplicationException(ApplicationExceptionType.GLOBAL_INTERNAL_SERVER_ERROR,
+                                new ApplicationException(
+                                        ApplicationExceptionType.GLOBAL_INTERNAL_SERVER_ERROR,
                                         "MemberId for BungaeDto projection cannot be null"));
 
         return new QBungaeDto(

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -44,7 +44,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
 
         List<BungaeDto> fetchedContent =
                 queryFactory
-                        .select(createBungaeDtoProjection(memberId))
+                        .select(createBungaeDtoProjection())
                         .from(bungae)
                         .join(attendee)
                         .on(attendee.bungae.eq(bungae))
@@ -106,6 +106,28 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 (statuses == null || statuses.isEmpty()) ? null : bungae.status.in(statuses);
 
         return Expressions.allOf(statusCondition, cursorId != null ? bungae.id.lt(cursorId) : null);
+    }
+
+    private Expression<BungaeDto> createBungaeDtoProjection() {
+        return new QBungaeDto(
+                bungae.id,
+                bungae.name,
+                bungae.description,
+                bungae.minAttendees,
+                bungae.maxAttendees,
+                bungae.isOnline,
+                bungae.location,
+                bungae.bungaeDateTime.date,
+                bungae.bungaeDateTime.time,
+                bungae.dateVoteClosedAt,
+                bungae.status,
+                bungae.audit.createdAt,
+                bungae.deleted,
+                bungae.group.id,
+                bungae.host.id,
+                createAttendeeCountSubQuery(),
+                Expressions.nullExpression(Boolean.class),
+                Expressions.nullExpression(Boolean.class));
     }
 
     private Expression<BungaeDto> createBungaeDtoProjection(Long memberId) {

--- a/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.midasdev.mybg.bungae.repository;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.domain.QBungae;
 import com.midasdev.mybg.bungae.domain.QBungaeAttendee;
+import com.midasdev.mybg.bungae.domain.QBungaeDateVote;
+import com.midasdev.mybg.bungae.domain.QBungaeRecruitDateOption;
 import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
 import com.midasdev.mybg.bungae.repository.dto.QBungaeDto;
 import com.midasdev.mybg.global.util.cursor_page.CursorPage;
@@ -42,7 +44,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
 
         List<BungaeDto> fetchedContent =
                 queryFactory
-                        .select(createBungaeDtoProjection())
+                        .select(createBungaeDtoProjection(memberId))
                         .from(bungae)
                         .join(attendee)
                         .on(attendee.bungae.eq(bungae))
@@ -58,7 +60,10 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
 
     @Override
     public CursorPage<BungaeDto> findByGroupIdAndStatusIn(
-            Long groupId, List<BungaeStatus> statuses, CursorPageable cursorPageable) {
+            Long groupId,
+            List<BungaeStatus> statuses,
+            CursorPageable cursorPageable,
+            Long memberId) {
         Long cursorId = cursorPageable.lastCursorId();
         int pageSize = cursorPageable.pageSize();
 
@@ -69,7 +74,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
 
         List<BungaeDto> fetchedContent =
                 queryFactory
-                        .select(createBungaeDtoProjection())
+                        .select(createBungaeDtoProjection(memberId))
                         .from(bungae)
                         .join(bungae.group)
                         .join(bungae.host)
@@ -82,10 +87,10 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
     }
 
     @Override
-    public Optional<BungaeDto> findBungaeDtoById(Long bungaeId) {
+    public Optional<BungaeDto> findBungaeDtoById(Long bungaeId, Long memberId) {
         BungaeDto result =
                 queryFactory
-                        .select(createBungaeDtoProjection())
+                        .select(createBungaeDtoProjection(memberId))
                         .from(bungae)
                         .join(bungae.group)
                         .join(bungae.host)
@@ -103,7 +108,7 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
         return Expressions.allOf(statusCondition, cursorId != null ? bungae.id.lt(cursorId) : null);
     }
 
-    private Expression<BungaeDto> createBungaeDtoProjection() {
+    private Expression<BungaeDto> createBungaeDtoProjection(Long memberId) {
         return new QBungaeDto(
                 bungae.id,
                 bungae.name,
@@ -120,12 +125,43 @@ public class CustomBungaeRepositoryImpl implements CustomBungaeRepository {
                 bungae.deleted,
                 bungae.group.id,
                 bungae.host.id,
-                createAttendeeCountSubQuery());
+                createAttendeeCountSubQuery(),
+                createHasJoinedSubQuery(memberId),
+                createHasVotedSubQuery(memberId));
     }
 
     private JPQLQuery<Integer> createAttendeeCountSubQuery() {
         return JPAExpressions.select(attendee.count().intValue())
                 .from(attendee)
                 .where(attendee.bungae.eq(bungae).and(attendee.deleted.isFalse()));
+    }
+
+    private Expression<Boolean> createHasJoinedSubQuery(Long memberId) {
+        if (memberId == null) {
+            return Expressions.nullExpression(Boolean.class);
+        }
+
+        QBungaeAttendee subAttendee = new QBungaeAttendee("subAttendee");
+        return JPAExpressions.selectOne()
+                .from(subAttendee)
+                .where(
+                        subAttendee.bungae.eq(bungae),
+                        subAttendee.groupMember.member.id.eq(memberId),
+                        subAttendee.deleted.isFalse())
+                .exists();
+    }
+
+    private Expression<Boolean> createHasVotedSubQuery(Long memberId) {
+        if (memberId == null) {
+            return Expressions.nullExpression(Boolean.class);
+        }
+
+        QBungaeDateVote bungaeDateVote = QBungaeDateVote.bungaeDateVote;
+        QBungaeRecruitDateOption dateOption = QBungaeRecruitDateOption.bungaeRecruitDateOption;
+        return JPAExpressions.selectOne()
+                .from(bungaeDateVote)
+                .join(bungaeDateVote.dateOption, dateOption)
+                .where(dateOption.bungae.eq(bungae), bungaeDateVote.voter.member.id.eq(memberId))
+                .exists();
     }
 }

--- a/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
+++ b/src/main/java/com/midasdev/mybg/bungae/repository/dto/BungaeDto.java
@@ -23,7 +23,9 @@ public record BungaeDto(
         Boolean deleted,
         Long groupId,
         Long hostGroupMemberId,
-        Integer attendeeCount)
+        Integer attendeeCount,
+        Boolean hasJoined,
+        Boolean hasVoted)
         implements LongIdentifiable {
 
     @QueryProjection

--- a/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
+++ b/src/main/java/com/midasdev/mybg/bungae/service/BungaeService.java
@@ -153,7 +153,8 @@ public class BungaeService {
         groupMemberFinder.findByMemberAndGroup(member, group);
 
         // 3. 해당 그룹에 속하고 statuses에 포함된 번개모임 조회
-        return bungaeRepository.findByGroupIdAndStatusIn(groupId, statuses, pageable);
+        return bungaeRepository.findByGroupIdAndStatusIn(
+                groupId, statuses, pageable, member.getId());
     }
 
     public List<LocalDate> getBungaeDateVoteOptions(Member member, Long bungaeId) {
@@ -338,7 +339,7 @@ public class BungaeService {
 
         // 9. 상태 변경 후 최신 번개 정보를 다시 조회하여 반환
         return bungaeRepository
-                .findBungaeDtoById(bungaeId)
+                .findBungaeDtoById(bungaeId, member.getId())
                 .orElseThrow(
                         () ->
                                 new ApplicationException(

--- a/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
+++ b/src/main/java/com/midasdev/mybg/group/controller/GroupController.java
@@ -45,7 +45,7 @@ public class GroupController {
     private final GroupService groupService;
 
     @Operation(
-            summary = "그룹 생성 API",
+            summary = "[GROUP-006] 그룹 생성 API",
             description = "특정 사용자가 그룹을 생성합니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @PostMapping
@@ -57,7 +57,7 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "그룹 조회 By 초대코드",
+            summary = "[GROUP-005] 그룹 조회 By 초대코드",
             description = "초대 코드로 그룹을 조회합니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @GetMapping("/search")
@@ -68,7 +68,7 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "참여 중인 그룹 조회 API",
+            summary = "[GROUP-001] 참여 중인 그룹 조회 API",
             description = "사용자가 참여 중인 그룹을 조회합니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @GetMapping("/participating")
@@ -80,7 +80,7 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "그룹 인원 수 조회 API",
+            summary = "[GROUP-004] 그룹 인원 수 조회 API",
             description = "그룹의 인원 수를 조회합니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @GetMapping("/{groupId}/participants/count")
@@ -92,7 +92,7 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "그룹 정보 수정 API",
+            summary = "[GROUP-003] 그룹 정보 수정 API",
             description =
                     """
                     그룹의 이름, 프로필 이미지, 최대 인원 수를 수정합니다.
@@ -112,7 +112,7 @@ public class GroupController {
     }
 
     @Operation(
-            summary = "그룹 전체 멤버 조회 API",
+            summary = "[GROUP-007] 그룹 전체 멤버 조회 API",
             description =
                     """
                         특정 그룹의 전체 멤버 정보를 조회합니다.

--- a/src/main/java/com/midasdev/mybg/group_member/controller/GroupMemberController.java
+++ b/src/main/java/com/midasdev/mybg/group_member/controller/GroupMemberController.java
@@ -37,7 +37,7 @@ public class GroupMemberController {
 
     private final GroupMemberService groupMemberService;
 
-    @Operation(summary = "그룹 참여 API", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
+    @Operation(summary = "[GROUP_MEMBER-001] 그룹 참여 API", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @PostMapping
     public ResponseEntity<ActiveGroupMemberResponse> joinGroup(
             @AuthenticationPrincipal Member member,
@@ -47,7 +47,7 @@ public class GroupMemberController {
     }
 
     @Operation(
-            summary = "그룹 멤버 프로필 수정 API",
+            summary = "[GROUP_MEMBER-002] 그룹 멤버 프로필 수정 API",
             description = "그룹에 참여 중인 사용자의 닉네임과 프로필 이미지를 수정합니다.",
             security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @PatchMapping(
@@ -63,7 +63,7 @@ public class GroupMemberController {
     }
 
     @Operation(
-            summary = "그룹 나가기 API",
+            summary = "[GROUP_MEMBER-003] 그룹 나가기 API",
             description =
                     """
                 사용자가 참여한 그룹에서 나갑니다.

--- a/src/main/java/com/midasdev/mybg/group_member/controller/GroupMemberController.java
+++ b/src/main/java/com/midasdev/mybg/group_member/controller/GroupMemberController.java
@@ -37,7 +37,9 @@ public class GroupMemberController {
 
     private final GroupMemberService groupMemberService;
 
-    @Operation(summary = "[GROUP_MEMBER-001] 그룹 참여 API", security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
+    @Operation(
+            summary = "[GROUP_MEMBER-001] 그룹 참여 API",
+            security = @SecurityRequirement(name = SECURITY_SCHEME_NAME))
     @PostMapping
     public ResponseEntity<ActiveGroupMemberResponse> joinGroup(
             @AuthenticationPrincipal Member member,

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -7,6 +7,8 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import com.midasdev.mybg.bungae.domain.Bungae;
 import com.midasdev.mybg.bungae.domain.BungaeAttendee;
 import com.midasdev.mybg.bungae.domain.BungaeDateTime;
+import com.midasdev.mybg.bungae.domain.BungaeDateVote;
+import com.midasdev.mybg.bungae.domain.BungaeRecruitDateOption;
 import com.midasdev.mybg.bungae.domain.BungaeStatus;
 import com.midasdev.mybg.bungae.fixture.BungaeFixture;
 import com.midasdev.mybg.bungae.repository.dto.BungaeDto;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
@@ -44,12 +47,17 @@ import org.springframework.context.annotation.Import;
  * otherGroup의 RECRUITING, CLOSED 번개에도 참여
  */
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({QueryDslConfig.class, AuditingTestConfig.class})
 class CustomBungaeRepositoryTest {
 
     @Autowired private BungaeRepository bungaeRepository;
 
     @Autowired private BungaeAttendeeRepository bungaeAttendeeRepository;
+
+    @Autowired private BungaeRecruitDateOptionRepository bungaeRecruitDateOptionRepository;
+
+    @Autowired private BungaeDateVoteRepository bungaeDateVoteRepository;
 
     @Autowired private GroupRepository groupRepository;
 
@@ -60,6 +68,7 @@ class CustomBungaeRepositoryTest {
     private Member member, otherMember;
     private Group group, otherGroup;
     private GroupMember groupMember;
+    private GroupMember groupMember2;
     private GroupMember otherGroupMember;
     private GroupMember memberInOtherGroup;
     private List<Bungae> groupSavedBungaes;
@@ -75,6 +84,7 @@ class CustomBungaeRepositoryTest {
                 groupRepository.save(
                         GroupFixture.create(otherMember, "다른 그룹", "other-group-invitation-code"));
         groupMember = groupMemberRepository.save(GroupMemberFixture.create(group, member));
+        groupMember2 = groupMemberRepository.save(GroupMemberFixture.create(group, otherMember));
         otherGroupMember =
                 groupMemberRepository.save(GroupMemberFixture.create(otherGroup, otherMember));
         memberInOtherGroup =
@@ -109,7 +119,7 @@ class CustomBungaeRepositoryTest {
     }
 
     /** 번개 생성과 참여자 저장을 통합한 헬퍼 메서드 */
-    private void createBungaeAndSaveAttendee(
+    private Bungae createBungaeAndSaveAttendee(
             BiFunction<Group, GroupMember, Bungae> bungaeCreator,
             Group group,
             GroupMember host,
@@ -120,21 +130,25 @@ class CustomBungaeRepositoryTest {
             groupSavedBungaes.add(bungae);
         }
 
-        saveAttendee(bungae, host);
+        if (bungae.getStatus() != BungaeStatus.DATE_VOTING) {
+            saveAttendee(bungae, host);
 
-        // host가 member인 경우 memberJoinedBungaeIds에 추가
-        if (host.getMember().getId().equals(member.getId())) {
-            memberJoinedBungaeIds.add(bungae.getId());
-        }
-
-        for (GroupMember attendee : additionalAttendees) {
-            saveAttendee(bungae, attendee);
-
-            // 추가 참여자가 member인 경우 memberJoinedBungaeIds에 추가
-            if (attendee.getMember().getId().equals(member.getId())) {
+            // host가 member인 경우 memberJoinedBungaeIds에 추가
+            if (host.getMember().getId().equals(member.getId())) {
                 memberJoinedBungaeIds.add(bungae.getId());
             }
+
+            for (GroupMember attendee : additionalAttendees) {
+                saveAttendee(bungae, attendee);
+
+                // 추가 참여자가 member인 경우 memberJoinedBungaeIds에 추가
+                if (attendee.getMember().getId().equals(member.getId())) {
+                    memberJoinedBungaeIds.add(bungae.getId());
+                }
+            }
         }
+
+        return bungae;
     }
 
     private void saveAttendee(Bungae bungae, GroupMember groupMember) {
@@ -182,7 +196,7 @@ class CustomBungaeRepositoryTest {
                         member.getId(), targetStatuses, cursorPageable);
 
         // then
-        assertThat(result.getContent()).hasSize(3); // DATE_VOTING 1개 + RECRUITING 2개
+        assertThat(result.getContent()).hasSize(2); // RECRUITING 2개
         assertThat(result.getContent())
                 .extracting(BungaeDto::id)
                 .allMatch(memberJoinedBungaeIds::contains);
@@ -215,7 +229,6 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent())
                 .extracting(BungaeDto::status)
                 .contains(
-                        BungaeStatus.DATE_VOTING,
                         BungaeStatus.RECRUITING,
                         BungaeStatus.RECRUITING_CLOSED,
                         BungaeStatus.CLOSED,
@@ -520,6 +533,147 @@ class CustomBungaeRepositoryTest {
                     softly.assertThat(targetBungae.hostGroupMemberId())
                             .isEqualTo(testGroupMember.getId());
                     softly.assertThat(targetBungae.attendeeCount()).isEqualTo(2);
+                });
+    }
+
+    @Test
+    @DisplayName("BR-1-6: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 O, 투표 O")
+    void BR_1_6() {
+        //  === given ===
+        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember, groupMember2);
+
+        // Create date option (to represent past voting)
+        BungaeRecruitDateOption dateOption =
+                bungaeRecruitDateOptionRepository.save(
+                        BungaeRecruitDateOption.builder()
+                                .dateOption(LocalDate.now().plusDays(2))
+                                .bungae(testBungae)
+                                .build());
+
+        // Member votes
+        bungaeDateVoteRepository.save(
+                BungaeDateVote.builder().voter(groupMember).dateOption(dateOption).build());
+
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // === when ===
+        CursorPage<BungaeDto> result =
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, member.getId());
+
+        // === then ===
+        assertThat(result.getContent()).isNotEmpty();
+
+        List<BungaeDto> target =
+                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+        assertThat(target).hasSize(1);
+
+        BungaeDto targetBungae = target.get(0);
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(targetBungae.hasJoined()).isTrue();
+                    softly.assertThat(targetBungae.hasVoted()).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("BR-1-7: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 O, 투표 X")
+    void BR_1_7() {
+        // === given ===
+        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember);
+
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // === when === 
+        CursorPage<BungaeDto> result =
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, member.getId());
+
+        // === then ===
+        assertThat(result.getContent()).isNotEmpty();
+
+        List<BungaeDto> target =
+                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+        assertThat(target).hasSize(1);
+
+        BungaeDto targetBungae = target.get(0);
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(targetBungae.hasJoined()).isTrue();
+                    softly.assertThat(targetBungae.hasVoted()).isFalse();
+                });
+    }
+
+    @Test
+    @DisplayName("BR-1-8: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 X, 투표 O")
+    void BR_1_8() {
+        // === given ===
+        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithDateVoting, group, groupMember);
+
+        // Create date option
+        BungaeRecruitDateOption dateOption =
+                bungaeRecruitDateOptionRepository.save(
+                        BungaeRecruitDateOption.builder()
+                                .dateOption(LocalDate.now().plusDays(1))
+                                .bungae(testBungae)
+                                .build());
+
+        // Member votes but does NOT join
+        bungaeDateVoteRepository.save(
+                BungaeDateVote.builder().voter(groupMember).dateOption(dateOption).build());
+
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // === when ===
+        CursorPage<BungaeDto> result =
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, member.getId());
+
+        // === then ===
+        assertThat(result.getContent()).isNotEmpty();
+
+        List<BungaeDto> target =
+                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+        assertThat(target).hasSize(1);
+
+        BungaeDto targetBungae = target.get(0);
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(targetBungae.hasJoined()).isFalse();
+                    softly.assertThat(targetBungae.hasVoted()).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("BR-1-9: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 X, 투표 X")
+    void BR_1_9() {
+        // === given ===
+        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember);
+
+        // Member does NOT join and does NOT vote
+        CursorPageable cursorPageable = new CursorPageable(null, 10);
+
+        // === when ===
+        CursorPage<BungaeDto> result =
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, otherMember.getId());
+
+        // === then ===
+        assertThat(result.getContent()).isNotEmpty();
+
+        List<BungaeDto> target =
+                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+        assertThat(target).hasSize(1);
+
+        BungaeDto targetBungae = target.get(0);
+
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(targetBungae.hasJoined()).isFalse();
+                    softly.assertThat(targetBungae.hasVoted()).isFalse();
                 });
     }
 }

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -540,7 +540,9 @@ class CustomBungaeRepositoryTest {
     @DisplayName("BR-1-6: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 O, 투표 O")
     void BR_1_6() {
         //  === given ===
-        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember, groupMember2);
+        Bungae testBungae =
+                createBungaeAndSaveAttendee(
+                        BungaeFixture::createWithRecruiting, group, groupMember, groupMember2);
 
         // Create date option (to represent past voting)
         BungaeRecruitDateOption dateOption =
@@ -565,7 +567,9 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent()).isNotEmpty();
 
         List<BungaeDto> target =
-                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+                result.getContent().stream()
+                        .filter(dto -> dto.id().equals(testBungae.getId()))
+                        .toList();
         assertThat(target).hasSize(1);
 
         BungaeDto targetBungae = target.get(0);
@@ -581,11 +585,13 @@ class CustomBungaeRepositoryTest {
     @DisplayName("BR-1-7: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 O, 투표 X")
     void BR_1_7() {
         // === given ===
-        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember);
+        Bungae testBungae =
+                createBungaeAndSaveAttendee(
+                        BungaeFixture::createWithRecruiting, group, groupMember);
 
         CursorPageable cursorPageable = new CursorPageable(null, 10);
 
-        // === when === 
+        // === when ===
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
                         group.getId(), null, cursorPageable, member.getId());
@@ -594,7 +600,9 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent()).isNotEmpty();
 
         List<BungaeDto> target =
-                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+                result.getContent().stream()
+                        .filter(dto -> dto.id().equals(testBungae.getId()))
+                        .toList();
         assertThat(target).hasSize(1);
 
         BungaeDto targetBungae = target.get(0);
@@ -610,7 +618,9 @@ class CustomBungaeRepositoryTest {
     @DisplayName("BR-1-8: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 X, 투표 O")
     void BR_1_8() {
         // === given ===
-        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithDateVoting, group, groupMember);
+        Bungae testBungae =
+                createBungaeAndSaveAttendee(
+                        BungaeFixture::createWithDateVoting, group, groupMember);
 
         // Create date option
         BungaeRecruitDateOption dateOption =
@@ -635,7 +645,9 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent()).isNotEmpty();
 
         List<BungaeDto> target =
-                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+                result.getContent().stream()
+                        .filter(dto -> dto.id().equals(testBungae.getId()))
+                        .toList();
         assertThat(target).hasSize(1);
 
         BungaeDto targetBungae = target.get(0);
@@ -651,7 +663,9 @@ class CustomBungaeRepositoryTest {
     @DisplayName("BR-1-9: 참가 여부와 투표 여부가 올바르게 매핑되어 조회됨 - 참가 X, 투표 X")
     void BR_1_9() {
         // === given ===
-        Bungae testBungae = createBungaeAndSaveAttendee(BungaeFixture::createWithRecruiting, group, groupMember);
+        Bungae testBungae =
+                createBungaeAndSaveAttendee(
+                        BungaeFixture::createWithRecruiting, group, groupMember);
 
         // Member does NOT join and does NOT vote
         CursorPageable cursorPageable = new CursorPageable(null, 10);
@@ -665,7 +679,9 @@ class CustomBungaeRepositoryTest {
         assertThat(result.getContent()).isNotEmpty();
 
         List<BungaeDto> target =
-                result.getContent().stream().filter(dto -> dto.id().equals(testBungae.getId())).toList();
+                result.getContent().stream()
+                        .filter(dto -> dto.id().equals(testBungae.getId()))
+                        .toList();
         assertThat(target).hasSize(1);
 
         BungaeDto targetBungae = target.get(0);

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -260,7 +260,8 @@ class CustomBungaeRepositoryTest {
 
         // when
         CursorPage<BungaeDto> result =
-                bungaeRepository.findByGroupIdAndStatusIn(group.getId(), statuses, cursorPageable);
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), statuses, cursorPageable, null);
 
         // then
         assertThat(result.getContent()).hasSize(pageSize);
@@ -278,7 +279,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        group.getId(), targetStatuses, cursorPageable);
+                        group.getId(), targetStatuses, cursorPageable, null);
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -299,7 +300,8 @@ class CustomBungaeRepositoryTest {
 
         // when
         CursorPage<BungaeDto> result =
-                bungaeRepository.findByGroupIdAndStatusIn(group.getId(), null, cursorPageable);
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, null);
 
         // then
         assertThat(result.getContent()).hasSize(5);
@@ -314,7 +316,8 @@ class CustomBungaeRepositoryTest {
 
         // when
         CursorPage<BungaeDto> result =
-                bungaeRepository.findByGroupIdAndStatusIn(group.getId(), null, cursorPageable);
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        group.getId(), null, cursorPageable, null);
 
         // then
         // ID 기준 내림차순 정렬 확인 (최신순)
@@ -476,7 +479,8 @@ class CustomBungaeRepositoryTest {
 
         // when
         CursorPage<BungaeDto> result =
-                bungaeRepository.findByGroupIdAndStatusIn(testGroup.getId(), null, cursorPageable);
+                bungaeRepository.findByGroupIdAndStatusIn(
+                        testGroup.getId(), null, cursorPageable, null);
 
         // then
         assertThat(result.getContent()).isNotEmpty();

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -250,8 +250,8 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-1: 조건에 맞는 올바른 그룹 번개 조회 - lastCursorId, size")
-    void B_3_R_1() {
+    @DisplayName("BR-1-1: 조건에 맞는 올바른 그룹 번개 조회 - lastCursorId, size")
+    void BR_1_1() {
         // given
         Long lastCursorId = Long.MAX_VALUE;
         int pageSize = 2;
@@ -270,8 +270,8 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-2: 조건에 맞는 올바른 그룹 번개 조회 - status")
-    void B_3_R_2() {
+    @DisplayName("BR-1-2: 조건에 맞는 올바른 그룹 번개 조회 - status")
+    void BR_1_2() {
         // given
         List<BungaeStatus> targetStatuses = List.of(BungaeStatus.RECRUITING, BungaeStatus.CLOSED);
         CursorPageable cursorPageable = new CursorPageable(null, 10);
@@ -293,8 +293,8 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-3: 조건에 맞는 올바른 그룹 번개 조회 - status가 null일 경우")
-    void B_3_R_3() {
+    @DisplayName("BR-1-3: 조건에 맞는 올바른 그룹 번개 조회 - status가 null일 경우")
+    void BR_1_3() {
         // given
         CursorPageable cursorPageable = new CursorPageable(null, 10);
 
@@ -309,8 +309,8 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-4: lastCursorId가 null일 경우 가장 최근 것부터 그룹 번개 조회")
-    void B_3_R_4() {
+    @DisplayName("BR-1-4: lastCursorId가 null일 경우 가장 최근 것부터 그룹 번개 조회")
+    void BR_1_4() {
         // given
         CursorPageable cursorPageable = new CursorPageable(null, 3);
 
@@ -429,13 +429,13 @@ class CustomBungaeRepositoryTest {
     }
 
     @Test
-    @DisplayName("B-3-R-5: 정확한 값이 있는 그룹 번개 조회")
-    void B_3_R_5() {
+    @DisplayName("BR-1-5: 정확한 값이 있는 그룹 번개 조회")
+    void BR_1_5() {
         // given
-        Member testMember = memberRepository.save(MemberFixture.create("B-3-R-5"));
+        Member testMember = memberRepository.save(MemberFixture.create("BR-1-5"));
         Group testGroup =
                 groupRepository.save(
-                        GroupFixture.create(testMember, "B-3-R-5 그룹", "B-3-R-5-invitation-code"));
+                        GroupFixture.create(testMember, "BR-1-5 그룹", "BR-1-5-invitation-code"));
         GroupMember testGroupMember =
                 groupMemberRepository.save(GroupMemberFixture.create(testGroup, testMember));
         GroupMember testGroupMember2 =

--- a/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
+++ b/src/test/java/com/midasdev/mybg/bungae/repository/CustomBungaeRepositoryTest.java
@@ -261,7 +261,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        group.getId(), statuses, cursorPageable, null);
+                        group.getId(), statuses, cursorPageable, member.getId());
 
         // then
         assertThat(result.getContent()).hasSize(pageSize);
@@ -279,7 +279,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        group.getId(), targetStatuses, cursorPageable, null);
+                        group.getId(), targetStatuses, cursorPageable, member.getId());
 
         // then
         assertThat(result.getContent()).hasSize(2);
@@ -301,7 +301,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        group.getId(), null, cursorPageable, null);
+                        group.getId(), null, cursorPageable, member.getId());
 
         // then
         assertThat(result.getContent()).hasSize(5);
@@ -317,7 +317,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        group.getId(), null, cursorPageable, null);
+                        group.getId(), null, cursorPageable, member.getId());
 
         // then
         // ID 기준 내림차순 정렬 확인 (최신순)
@@ -480,7 +480,7 @@ class CustomBungaeRepositoryTest {
         // when
         CursorPage<BungaeDto> result =
                 bungaeRepository.findByGroupIdAndStatusIn(
-                        testGroup.getId(), null, cursorPageable, null);
+                        testGroup.getId(), null, cursorPageable, member.getId());
 
         // then
         assertThat(result.getContent()).isNotEmpty();


### PR DESCRIPTION
# 🔍 Summary
그룹별 번개 조회와 번개 참여 응답으로 참여 및 신청 여부 정보를 포함합니다.

# 📑 Description
- BungaeResposne에 번개 참여 및 신청 여부 정보 포함
- 그룹별 번개 조회와 번개 참여 API 만 바뀌도록 적용
- 조회 리포지토리 테스트 추가

# 🔗 Related Issues
- #65 

# ✅ Checklist
- [x] Base-Compare Branch 확인
- [x] Assignees 설정